### PR TITLE
Allow different round modes when converting currency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Money Changelog
 2.0.0.dev
 ---------
 
+- 2013-08-18 Introduce RoundingMode object, used to specify desired rounding
+- 2013-08-18 Introduced RoundingMode backwards compatible API changes to Money::multiply and Money::divide
+- 2013-08-18 Allow RoundingMode to be specified when converting currencies
 - 2013-01-08 Removed the Doctrine2\MoneyType helper, to be replaced by something better in the future. It's available
              at https://gist.github.com/4485025 in case you need it.
 - 2013-01-08 Use vendor/autoload.php instead of lib/bootstrap.php (or use PSR-0 autolaoding)

--- a/lib/Money/CurrencyPair.php
+++ b/lib/Money/CurrencyPair.php
@@ -25,7 +25,7 @@ class CurrencyPair
     /**
      * @param \Money\Currency $counterCurrency
      * @param \Money\Currency $baseCurrency
-     * @param float $ratio
+     * @param float           $ratio
      * @throws \Money\InvalidArgumentException
      */
     public function __construct(Currency $counterCurrency, Currency $baseCurrency, $ratio)
@@ -61,17 +61,22 @@ class CurrencyPair
 
     /**
      * @param \Money\Money $money
-     * @throws InvalidArgumentException
+     * @param              $rounding_mode
      * @return \Money\Money
+     * @throws \Money\InvalidArgumentException
      */
-    public function convert(Money $money)
+    public function convert(Money $money, RoundingMode $rounding_mode = null)
     {
         if (!$money->getCurrency()->equals($this->counterCurrency)) {
             throw new InvalidArgumentException("The Money has the wrong currency");
         }
 
-        // @todo add rounding mode?
-        return new Money((int) round($money->getAmount() * $this->ratio), $this->baseCurrency);
+        $rounding_mode = $rounding_mode ?: RoundingMode::halfUp();
+        
+        return new Money(
+            (int) round($money->getAmount() * $this->ratio, 0, $rounding_mode->getRoundingMode()),
+            $this->baseCurrency
+        );
     }
 
     /** @return \Money\Currency */

--- a/lib/Money/Money.php
+++ b/lib/Money/Money.php
@@ -174,41 +174,37 @@ class Money
     }
 
     /**
-     * @throws \Money\InvalidArgumentException
-     */
-    private function assertRoundingMode($rounding_mode)
-    {
-        if (!in_array($rounding_mode, array(self::ROUND_HALF_DOWN, self::ROUND_HALF_EVEN, self::ROUND_HALF_ODD, self::ROUND_HALF_UP))) {
-            throw new InvalidArgumentException('Rounding mode should be Money::ROUND_HALF_DOWN | Money::ROUND_HALF_EVEN | Money::ROUND_HALF_ODD | Money::ROUND_HALF_UP');
-        }
-    }
-
-    /**
      * @param $multiplier
-     * @param int $rounding_mode
+     * @param int|\Money\RoundingMode $rounding_mode
      * @return \Money\Money
      */
     public function multiply($multiplier, $rounding_mode = self::ROUND_HALF_UP)
     {
         $this->assertOperand($multiplier);
-        $this->assertRoundingMode($rounding_mode);
+        
+        if (!$rounding_mode instanceof RoundingMode) {
+            $rounding_mode = new RoundingMode($rounding_mode);
+        }
 
-        $product = (int) round($this->amount * $multiplier, 0, $rounding_mode);
+        $product = (int) round($this->amount * $multiplier, 0, $rounding_mode->getRoundingMode());
 
         return new Money($product, $this->currency);
     }
 
     /**
      * @param $divisor
-     * @param int $rounding_mode
+     * @param int|\Money\RoundingMode $rounding_mode
      * @return \Money\Money
      */
     public function divide($divisor, $rounding_mode = self::ROUND_HALF_UP)
     {
         $this->assertOperand($divisor);
-        $this->assertRoundingMode($rounding_mode);
 
-        $quotient = (int) round($this->amount / $divisor, 0, $rounding_mode);
+        if (!$rounding_mode instanceof RoundingMode) {
+            $rounding_mode = new RoundingMode($rounding_mode);
+        }
+
+        $quotient = (int) round($this->amount / $divisor, 0, $rounding_mode->getRoundingMode());
 
         return new Money($quotient, $this->currency);
     }
@@ -260,7 +256,7 @@ class Money
      * @throws \Money\InvalidArgumentException
      * @return int
      */
-    public static function stringToUnits( $string )
+    public static function stringToUnits($string)
     {
         //@todo extend the regular expression with grouping characters and eventually currencies
         if (!preg_match("/(-)?(\d+)([.,])?(\d)?(\d)?/", $string, $matches)) {

--- a/lib/Money/RoundingMode.php
+++ b/lib/Money/RoundingMode.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * This file is part of the Money library
+ *
+ * Copyright (c) 2011-2013 Mathias Verraes
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Money;
+
+class RoundingMode
+{
+    const ROUND_HALF_UP = PHP_ROUND_HALF_UP;
+    const ROUND_HALF_DOWN = PHP_ROUND_HALF_DOWN;
+    const ROUND_HALF_EVEN = PHP_ROUND_HALF_EVEN;
+    const ROUND_HALF_ODD = PHP_ROUND_HALF_ODD;
+
+    /**
+     * @var
+     */
+    private $roundingMode;
+
+    /**
+     * Create a rounding mode
+     * @param int $rounding_mode
+     * @throws InvalidArgumentException
+     */
+    public function __construct($rounding_mode)
+    {
+        if (!in_array(
+            $rounding_mode,
+            array(self::ROUND_HALF_DOWN, self::ROUND_HALF_EVEN, self::ROUND_HALF_ODD, self::ROUND_HALF_UP)
+        )) {
+            throw new InvalidArgumentException(
+                'Rounding mode should be RoundingMode::ROUND_HALF_DOWN | ' .
+                'RoundingMode::ROUND_HALF_EVEN | RoundingMode::ROUND_HALF_ODD | ' .
+                'RoundingMode::ROUND_HALF_UP'
+            );
+        }
+        
+        $this->roundingMode = $rounding_mode;
+    }
+
+    /**
+     * @return int
+     */
+    public function getRoundingMode()
+    {
+        return $this->roundingMode;
+    }
+
+    /**
+     * @return \Money\RoundingMode
+     */
+    public static function halfUp()
+    {
+        return new self(self::ROUND_HALF_UP);
+    }
+
+    /**
+     * @return \Money\RoundingMode
+     */
+    public static function halfDown()
+    {
+        return new self(self::ROUND_HALF_DOWN);
+    }
+
+    /**
+     * @return \Money\RoundingMode
+     */
+    public static function halfEven()
+    {
+        return new self(self::ROUND_HALF_EVEN);
+    }
+
+    /**
+     * @return \Money\RoundingMode
+     */
+    public static function halfOdd()
+    {
+        return new self(self::ROUND_HALF_ODD);
+    }
+}

--- a/tests/Money/Tests/CurrencyPairTest.php
+++ b/tests/Money/Tests/CurrencyPairTest.php
@@ -10,6 +10,7 @@
 
 namespace Money\Tests;
 
+use Money\RoundingMode;
 use PHPUnit_Framework_TestCase;
 use Money\Money;
 use Money\Currency;
@@ -29,6 +30,20 @@ class CurrencyPairTest extends PHPUnit_Framework_TestCase
         $pair = new CurrencyPair(new Currency('USD'), new Currency('EUR'), 0.8000);
         $eur = $pair->convert($usd);
         $this->assertEquals(Money::EUR(100), $eur);
+    }
+    
+    /** @test */
+    public function ConvertsEurToUsdWithModes()
+    {
+        $eur = Money::EUR(10);
+
+        $pair = new CurrencyPair(new Currency('EUR'), new Currency('USD'), 1.2500);
+        $usd = $pair->convert($eur);
+        $this->assertEquals(Money::USD(13), $usd);
+
+        $pair = new CurrencyPair(new Currency('EUR'), new Currency('USD'), 1.2500);
+        $usd = $pair->convert($eur, new RoundingMode(RoundingMode::ROUND_HALF_DOWN));
+        $this->assertEquals(Money::USD(12), $usd);
     }
 
     /** @test */

--- a/tests/Money/Tests/RoundingModeTest.php
+++ b/tests/Money/Tests/RoundingModeTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Money\Tests;
+
+use Money\RoundingMode;
+use PHPUnit_Framework_TestCase;
+
+class RoundingModeTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @test
+     */
+    public function Get()
+    {
+        $rounding_mode = new RoundingMode(RoundingMode::ROUND_HALF_DOWN);
+        
+        $this->assertEquals(RoundingMode::ROUND_HALF_DOWN, $rounding_mode->getRoundingMode());
+    }
+    /**
+     * @test
+     * @expectedException \Money\InvalidArgumentException
+     * @expectedExceptionMessage Rounding mode should be RoundingMode::ROUND_HALF_DOWN | RoundingMode::ROUND_HALF_EVEN | RoundingMode::ROUND_HALF_ODD | RoundingMode::ROUND_HALF_UP
+     */
+    public function ExceptionCheck()
+    {
+        new RoundingMode(999);
+    }
+}


### PR DESCRIPTION
I am a bit unsure about changing the access of `assertRoundingMode` to public. If you have any other suggestions I can change it.
- [x] adapt changelog
