### PR TITLE
Feature/allocate

### DIFF
--- a/src/Money.php
+++ b/src/Money.php
@@ -344,16 +344,12 @@ class Money
     /**
      * Allocate the money according to a list of ratios
      *
-     * @param mixed $ratios
+     * @param array $ratios
      *
      * @return Money[]
      */
-    public function allocate($ratios)
+    public function allocate(array $ratios)
     {
-        if (!is_array($ratios)) {
-            $ratios = func_get_args();
-        }
-
         $remainder = $this->amount;
         $results = array();
         $total = array_sum($ratios);

--- a/tests/MoneyTest.php
+++ b/tests/MoneyTest.php
@@ -234,7 +234,7 @@ class MoneyTest extends \PHPUnit_Framework_TestCase
     public function testAllocation()
     {
         $m = new Money(100, new Currency('EUR'));
-        list($part1, $part2, $part3) = $m->allocate(1, 1, 1);
+        list($part1, $part2, $part3) = $m->allocate(array(1, 1, 1));
         $this->assertEquals(new Money(34, new Currency('EUR')), $part1);
         $this->assertEquals(new Money(33, new Currency('EUR')), $part2);
         $this->assertEquals(new Money(33, new Currency('EUR')), $part3);


### PR DESCRIPTION
`allocate` now supports the following form: `$m->allocate(1, 1, 1)` (array can be ommited)

Adds `allocateTo`: Divides the amount to N equal values (the remainder is shared between the first K results)

Example:

``` php
$m = new Money::EUR(15);

// Returns [8, 7]
$m->allocateTo(2);
```

Please merge #55 before, so I can rebase this if needed
