### PR TITLE
Solution to #67 - throwing "Money\InvalidArgumentException: The value co...

### DIFF
--- a/lib/Money/Money.php
+++ b/lib/Money/Money.php
@@ -260,13 +260,14 @@ class Money
      * @throws \Money\InvalidArgumentException
      * @return int
      */
-    public static function stringToUnits( $string )
+    public static function stringToUnits($string)
     {
         $sign = "(?P<sign>[-\+])?";
         $digits = "(?P<digits>\d*)";
         $separator = "(?P<separator>[.,])?";
         $decimals = "(?P<decimal1>\d)?(?P<decimal2>\d)?";
-        $pattern = "/^".$sign.$digits.$separator.$decimals."$/";
+        $zeroes = "0*";
+        $pattern = "/^" . $sign . $digits . $separator . $decimals . $zeroes . "$/";
 
         if (!preg_match($pattern, trim($string), $matches)) {
             throw new InvalidArgumentException("The value could not be parsed as money");
@@ -277,6 +278,6 @@ class Money
         $units .= isset($matches['decimal1']) ? $matches['decimal1'] : "0";
         $units .= isset($matches['decimal2']) ? $matches['decimal2'] : "0";
 
-        return (int) $units;
+        return (int)$units;
     }
 }

--- a/tests/Money/Tests/MoneyTest.php
+++ b/tests/Money/Tests/MoneyTest.php
@@ -228,6 +228,9 @@ class MoneyTest extends PHPUnit_Framework_TestCase
             array("+1", 100),
             array(".99", 99),
             array("-.99", -99),
+            array("0000.120000", 12),
+            array(".00", 0),
+            array("2.000", 200)
         );
     }
 


### PR DESCRIPTION
...uld not be parsed as money" on stringToUnits when string have more than two zeroes after the separator.

 Adding tests samples.
