### PR TITLE
test different style when parsing

### DIFF
--- a/tests/IntlMoneyParserTest.php
+++ b/tests/IntlMoneyParserTest.php
@@ -88,4 +88,16 @@ final class IntlMoneyParserTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('1000005', $money->getAmount());
     }
+
+    public function testDifferentStyleWithPattern()
+    {
+        $formatter = new \NumberFormatter('en_US', \NumberFormatter::DECIMAL);
+        $formatter->setPattern("¤#,##0.00;-¤#,##0.00");
+        $formatter->setAttribute(\NumberFormatter::FRACTION_DIGITS, 3);
+
+        $parser = new IntlMoneyParser($formatter);
+        $money = $parser->parse('$1000.005');
+
+        $this->assertEquals('1000005', $money->getAmount());
+    }
 }


### PR DESCRIPTION
Different style with pattern always works. Different style without pattern throws an exception. I am fine with that behaviour.