### PR TITLE
Remove float from currency pair

### DIFF
--- a/src/CurrencyPair.php
+++ b/src/CurrencyPair.php
@@ -45,7 +45,7 @@ final class CurrencyPair implements \JsonSerializable
 
         $this->counterCurrency = $counterCurrency;
         $this->baseCurrency = $baseCurrency;
-        $this->conversionRatio = (float) $conversionRatio;
+        $this->conversionRatio = (string) $conversionRatio;
     }
 
     /**
@@ -73,7 +73,7 @@ final class CurrencyPair implements \JsonSerializable
             );
         }
 
-        return new static(new Currency($matches[1]), new Currency($matches[2]), $matches[3]);
+        return new self(new Currency($matches[1]), new Currency($matches[2]), $matches[3]);
     }
 
     /**

--- a/tests/CurrencyPairTest.php
+++ b/tests/CurrencyPairTest.php
@@ -78,6 +78,21 @@ final class CurrencyPairTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(Money::EUR(100), $eur);
     }
 
+    public function testConvertsArsToUsdAndBack()
+    {
+        $ratio = '14.834670';
+        $inverseRatio = '0.067409656';
+
+        $pair = CurrencyPair::createFromISO('USD/ARS '.$ratio);
+        $inversePair = CurrencyPair::createFromISO('ARS/USD '.$inverseRatio);
+
+        $moneyUsd = new Money(286, new Currency('USD'));
+        $moneyArs = new Money(4243, new Currency('ARS'));
+
+        $this->assertEquals(4243, $pair->convert($moneyUsd)->getAmount());
+        $this->assertEquals(286, $inversePair->convert($moneyArs)->getAmount());
+    }
+
     public function testConvertsEurToUsdWithModes()
     {
         $eur = Money::EUR(10);
@@ -117,7 +132,7 @@ final class CurrencyPairTest extends \PHPUnit_Framework_TestCase
 
     public function testJsonEncoding()
     {
-        $expected_json = '{"baseCurrency":"EUR","counterCurrency":"USD","ratio":1.25}';
+        $expected_json = '{"baseCurrency":"EUR","counterCurrency":"USD","ratio":"1.25"}';
         $actual_json = json_encode(new CurrencyPair(new Currency('EUR'), new Currency('USD'), 1.25));
 
         $this->assertEquals($expected_json, $actual_json);

--- a/tests/Exchange/SwapExchangeTest.php
+++ b/tests/Exchange/SwapExchangeTest.php
@@ -37,7 +37,7 @@ class SwapExchangeTest extends \PHPUnit_Framework_TestCase
         );
 
         $this->assertSame(
-            1.0,
+            '1',
             $currencyPair->getConversionRatio()
         );
     }


### PR DESCRIPTION
@sagikazarmark While testing issue #189 I found that `CurrencyPair` is using `(float)`. I think it would be better if we get rid of it, and use `(string)`. This also has consequences for the json representation, because that will be using quotation marks now. What do you think?