### PR TITLE
Bitcoin namespace and currencies

### DIFF
--- a/src/Currencies/BitcoinCurrencies.php
+++ b/src/Currencies/BitcoinCurrencies.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Money\Currencies;
+
+use Money\Currencies;
+use Money\Currency;
+
+/**
+ * @author Frederik Bosch <f.bosch@genkgo.nl>
+ */
+final class BitcoinCurrencies implements Currencies
+{
+    const CODE = 'XBT';
+    const SYMBOL = "\0xC9\0x83";
+
+    /**
+     * {@inheritdoc}
+     */
+    public function contains(Currency $currency)
+    {
+        return self::CODE === $currency->getCode();
+    }
+}

--- a/src/Formatter/BitcoinMoneyFormatter.php
+++ b/src/Formatter/BitcoinMoneyFormatter.php
@@ -2,19 +2,17 @@
 
 namespace Money\Formatter;
 
+use Money\Currencies\BitcoinCurrencies;
 use Money\Money;
 use Money\MoneyFormatter;
-use Money\Parser\BitcoinSupportedMoneyParser;
 
 /**
  * Formats Money to Bitcoin currency.
  *
  * @author Frederik Bosch <f.bosch@genkgo.nl>
  */
-final class BitcoinSupportedMoneyFormatter implements MoneyFormatter
+final class BitcoinMoneyFormatter implements MoneyFormatter
 {
-    const CODE = 'XBT';
-
     /**
      * @var MoneyFormatter
      */
@@ -36,22 +34,18 @@ final class BitcoinSupportedMoneyFormatter implements MoneyFormatter
     }
 
     /**
-     * Formats a Money object as string.
-     *
-     * @param Money $money
-     *
-     * @return string
+     * {@inheritdoc}
      */
     public function format(Money $money)
     {
-        if ($money->getCurrency()->getCode() !== self::CODE) {
+        if (BitcoinCurrencies::CODE !== $money->getCurrency()->getCode()) {
             return $this->delegatedFormatter->format($money);
         }
 
-        $valueBase = (string) $money->getAmount();
+        $valueBase = $money->getAmount();
         $negative = false;
 
-        if (substr($valueBase, 0, 1) === '-') {
+        if ('-' === substr($valueBase, 0, 1)) {
             $negative = true;
             $valueBase = substr($valueBase, 1);
         }
@@ -61,6 +55,7 @@ final class BitcoinSupportedMoneyFormatter implements MoneyFormatter
 
         if ($valueLength > $fractionDigits) {
             $subunits = substr($valueBase, 0, $valueLength - $fractionDigits);
+
             if ($fractionDigits) {
                 $subunits .= '.';
                 $subunits .= substr($valueBase, $valueLength - $fractionDigits);
@@ -69,10 +64,10 @@ final class BitcoinSupportedMoneyFormatter implements MoneyFormatter
             $subunits = '0.'.str_pad('', $fractionDigits - $valueLength, '0').$valueBase;
         }
 
-        if ($negative === true) {
-            $subunits = '-'.BitcoinSupportedMoneyParser::SYMBOL.$subunits;
-        } else {
-            $subunits = BitcoinSupportedMoneyParser::SYMBOL.$subunits;
+        $subunits = BitcoinCurrencies::SYMBOL.$subunits;
+
+        if (true === $negative) {
+            $subunits = '-'.BitcoinCurrencies::SYMBOL.$subunits;
         }
 
         return $subunits;

--- a/src/Parser/BitcoinMoneyParser.php
+++ b/src/Parser/BitcoinMoneyParser.php
@@ -2,8 +2,8 @@
 
 namespace Money\Parser;
 
+use Money\Currencies\BitcoinCurrencies;
 use Money\Currency;
-use Money\Formatter\BitcoinSupportedMoneyFormatter;
 use Money\Money;
 use Money\MoneyParser;
 
@@ -12,10 +12,8 @@ use Money\MoneyParser;
  *
  * @author Frederik Bosch <f.bosch@genkgo.nl>
  */
-final class BitcoinSupportedMoneyParser implements MoneyParser
+final class BitcoinMoneyParser implements MoneyParser
 {
-    const SYMBOL = "\0xC9\0x83";
-
     /**
      * @var MoneyParser
      */
@@ -41,13 +39,14 @@ final class BitcoinSupportedMoneyParser implements MoneyParser
      */
     public function parse($money, $forceCurrency = null)
     {
-        if (strpos($money, self::SYMBOL) === false) {
+        if (false === strpos($money, BitcoinCurrencies::SYMBOL)) {
             return $this->delegatedParser->parse($money, $forceCurrency);
         }
 
-        $decimal = str_replace(self::SYMBOL, '', $money);
+        $decimal = str_replace(BitcoinCurrencies::SYMBOL, '', $money);
         $decimalSeparator = strpos($decimal, '.');
-        if ($decimalSeparator !== false) {
+
+        if (false !== $decimalSeparator) {
             $lengthDecimal = strlen($decimal);
             $decimal = str_replace('.', '', $decimal);
             $decimal .= str_pad('', ($lengthDecimal - $decimalSeparator - $this->fractionDigits - 1) * -1, '0');
@@ -55,16 +54,16 @@ final class BitcoinSupportedMoneyParser implements MoneyParser
             $decimal .= str_pad('', $this->fractionDigits, '0');
         }
 
-        if (substr($decimal, 0, 1) === '-') {
+        if ('-' === substr($decimal, 0, 1)) {
             $decimal = '-'.ltrim(substr($decimal, 1), '0');
         } else {
             $decimal = ltrim($decimal, '0');
         }
 
-        if ($decimal === '') {
+        if ('' === $decimal) {
             $decimal = '0';
         }
 
-        return new Money($decimal, new Currency(BitcoinSupportedMoneyFormatter::CODE));
+        return new Money($decimal, new Currency(BitcoinCurrencies::CODE));
     }
 }

--- a/tests/Currencies/BitcoinCurrenciesTest.php
+++ b/tests/Currencies/BitcoinCurrenciesTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Tests\Money\Currencies;
+
+use Money\Currencies\BitcoinCurrencies;
+use Money\Currency;
+
+final class BitcoinCurrenciesTest extends \PHPUnit_Framework_TestCase
+{
+    public function test()
+    {
+        $bitcoinCurrencies = new BitcoinCurrencies();
+
+        $this->assertTrue($bitcoinCurrencies->contains(new Currency('XBT')));
+    }
+}

--- a/tests/Formatter/BitcoinMoneyFormatterTest.php
+++ b/tests/Formatter/BitcoinMoneyFormatterTest.php
@@ -2,12 +2,12 @@
 
 namespace Tests\Money\Formatter;
 
-use Money\Formatter\BitcoinSupportedMoneyFormatter;
+use Money\Formatter\BitcoinMoneyFormatter;
 use Money\Currency;
 use Money\Formatter\IntlMoneyFormatter;
 use Money\Money;
 
-final class BitcoinSupportedMoneyFormatterTest extends \PHPUnit_Framework_TestCase
+final class BitcoinMoneyFormatterTest extends \PHPUnit_Framework_TestCase
 {
     public function testRoundMoney()
     {
@@ -17,7 +17,7 @@ final class BitcoinSupportedMoneyFormatterTest extends \PHPUnit_Framework_TestCa
         $numberFormatter->setPattern('¤#,##0.00;-¤#,##0.00');
 
         $intlFormatter = new IntlMoneyFormatter($numberFormatter);
-        $formatter = new BitcoinSupportedMoneyFormatter($intlFormatter, 2);
+        $formatter = new BitcoinMoneyFormatter($intlFormatter, 2);
         $this->assertEquals("\0xC9\0x831000.00", $formatter->format($money));
     }
 
@@ -29,7 +29,7 @@ final class BitcoinSupportedMoneyFormatterTest extends \PHPUnit_Framework_TestCa
         $numberFormatter->setPattern('¤#,##0.00;-¤#,##0.00');
 
         $intlFormatter = new IntlMoneyFormatter($numberFormatter);
-        $formatter = new BitcoinSupportedMoneyFormatter($intlFormatter, 2);
+        $formatter = new BitcoinMoneyFormatter($intlFormatter, 2);
         $this->assertEquals("\0xC9\0x830.41", $formatter->format($money));
     }
 
@@ -41,7 +41,7 @@ final class BitcoinSupportedMoneyFormatterTest extends \PHPUnit_Framework_TestCa
         $numberFormatter->setPattern('¤#,##0.00;-¤#,##0.00');
 
         $intlFormatter = new IntlMoneyFormatter($numberFormatter);
-        $formatter = new BitcoinSupportedMoneyFormatter($intlFormatter, 2);
+        $formatter = new BitcoinMoneyFormatter($intlFormatter, 2);
         $this->assertEquals("\0xC9\0x830.05", $formatter->format($money));
     }
 
@@ -53,7 +53,7 @@ final class BitcoinSupportedMoneyFormatterTest extends \PHPUnit_Framework_TestCa
         $numberFormatter->setPattern('¤#,##0.00;-¤#,##0.00');
 
         $intlFormatter = new IntlMoneyFormatter($numberFormatter);
-        $formatter = new BitcoinSupportedMoneyFormatter($intlFormatter, 0);
+        $formatter = new BitcoinMoneyFormatter($intlFormatter, 0);
         $this->assertEquals("\0xC9\0x835", $formatter->format($money));
     }
 
@@ -65,7 +65,7 @@ final class BitcoinSupportedMoneyFormatterTest extends \PHPUnit_Framework_TestCa
         $numberFormatter->setPattern('¤#,##0.00;-¤#,##0.00');
 
         $intlFormatter = new IntlMoneyFormatter($numberFormatter);
-        $formatter = new BitcoinSupportedMoneyFormatter($intlFormatter, 4);
+        $formatter = new BitcoinMoneyFormatter($intlFormatter, 4);
         $this->assertEquals("\0xC9\0x830.0005", $formatter->format($money));
     }
 
@@ -77,7 +77,7 @@ final class BitcoinSupportedMoneyFormatterTest extends \PHPUnit_Framework_TestCa
         $numberFormatter->setPattern('¤#,##0.00;-¤#,##0.00');
 
         $intlFormatter = new IntlMoneyFormatter($numberFormatter);
-        $formatter = new BitcoinSupportedMoneyFormatter($intlFormatter, 2);
+        $formatter = new BitcoinMoneyFormatter($intlFormatter, 2);
         $this->assertEquals('$0.05', $formatter->format($money));
     }
 }

--- a/tests/Parser/BitcoinMoneyParserTest.php
+++ b/tests/Parser/BitcoinMoneyParserTest.php
@@ -2,10 +2,10 @@
 
 namespace Tests\Money\Parser;
 
-use Money\Parser\BitcoinSupportedMoneyParser;
+use Money\Parser\BitcoinMoneyParser;
 use Money\Parser\IntlMoneyParser;
 
-final class BitcoinSupportedMoneyParserTest extends \PHPUnit_Framework_TestCase
+final class BitcoinMoneyParserTest extends \PHPUnit_Framework_TestCase
 {
     public static function provideFormattedMoney()
     {
@@ -41,7 +41,7 @@ final class BitcoinSupportedMoneyParserTest extends \PHPUnit_Framework_TestCase
 
         $intlParser = new IntlMoneyParser($formatter);
 
-        $parser = new BitcoinSupportedMoneyParser($intlParser, 2);
+        $parser = new BitcoinMoneyParser($intlParser, 2);
         $this->assertEquals($units, $parser->parse($string, 'USD')->getAmount());
     }
 
@@ -52,7 +52,7 @@ final class BitcoinSupportedMoneyParserTest extends \PHPUnit_Framework_TestCase
 
         $intlParser = new IntlMoneyParser($formatter);
 
-        $parser = new BitcoinSupportedMoneyParser($intlParser, 2);
+        $parser = new BitcoinMoneyParser($intlParser, 2);
         $this->assertEquals('100000', $parser->parse('$1000.00', 'USD')->getAmount());
     }
 
@@ -62,7 +62,7 @@ final class BitcoinSupportedMoneyParserTest extends \PHPUnit_Framework_TestCase
         $formatter->setPattern('¤#,##0.00;-¤#,##0.00');
 
         $intlParser = new IntlMoneyParser($formatter);
-        $parser = new BitcoinSupportedMoneyParser($intlParser, 2);
+        $parser = new BitcoinMoneyParser($intlParser, 2);
         $parsed = $parser->parse('$1000.00', 'XBT');
 
         $this->assertEquals('100000', $parsed->getAmount());


### PR DESCRIPTION
Move bitcoin to own namespace, rename classes, add currencies implementation. Fixed #197.