### PR TITLE
Add extra optional argument subunits to IntlMoneyFormatter.

### DIFF
--- a/doc/Formatting.rst
+++ b/doc/Formatting.rst
@@ -10,7 +10,9 @@ Money comes with the following implementations out of the box:
 Intl Formatter
 --------------
 
-As it's name says, this formatter requires the `intl` extension and uses ``NumberFormatter``.
+As it's name says, this formatter requires the `intl` extension and uses the ``NumberFormatter`` class from the
+extension. Because ``Money`` is not aware of the amount subunits, you should give that as second constructor
+argument.
 
 
 .. warning::
@@ -25,8 +27,9 @@ As it's name says, this formatter requires the `intl` extension and uses ``Numbe
 
     $money = new Money(100, new Currency('USD'));
 
+    $subunits = 2;
     $numberFormatter = new \NumberFormatter('en_US', \NumberFormatter::CURRENCY);
-    $moneyFormatter = new IntlMoneyFormatter($numberFormatter);
+    $moneyFormatter = new IntlMoneyFormatter($numberFormatter, $subunits);
 
     echo $moneyFormatter->format($money); // outputs $1.00
 
@@ -48,8 +51,9 @@ currency code.
     $dollars = new Money(100, new Currency('USD'));
     $bitcoin = new Money(100, new Currency('XBT'));
 
+    $dollarSubunits = 2;
     $numberFormatter = new \NumberFormatter('en_US', \NumberFormatter::CURRENCY);
-    $intlFormatter = new IntlMoneyFormatter($numberFormatter);
+    $intlFormatter = new IntlMoneyFormatter($numberFormatter, $dollarSubunits);
     $bitcoinFormatter = new BitcoinMoneyFormatter(2);
 
     $moneyFormatter = new AggregateFormatter([

--- a/spec/Formatter/IntlMoneyFormatterSpec.php
+++ b/spec/Formatter/IntlMoneyFormatterSpec.php
@@ -27,10 +27,22 @@ class IntlMoneyFormatterSpec extends ObjectBehavior
     function it_formats_money(\NumberFormatter $numberFormatter)
     {
         $numberFormatter->getAttribute(\NumberFormatter::FRACTION_DIGITS)->willReturn(2);
-        $numberFormatter->formatCurrency('0.01', 'EUR')->willReturn('€1.00');
+        $numberFormatter->formatCurrency('1.', 'EUR')->willReturn('€0.01');
 
         $money = new Money(1, new Currency('EUR'));
 
-        $this->format($money)->shouldReturn('€1.00');
+        $this->format($money)->shouldReturn('€0.01');
+    }
+
+
+    function it_formats_with_subunits(\NumberFormatter $numberFormatter)
+    {
+        $this->beConstructedWith($numberFormatter, 2);
+
+        $numberFormatter->formatCurrency('5.00', 'USD')->willReturn('$5');
+
+        $money = new Money(500, new Currency('USD'));
+
+        $this->format($money)->shouldReturn('$5');
     }
 }

--- a/src/Formatter/IntlMoneyFormatter.php
+++ b/src/Formatter/IntlMoneyFormatter.php
@@ -16,13 +16,23 @@ final class IntlMoneyFormatter implements MoneyFormatter
      * @var \NumberFormatter
      */
     private $formatter;
+    /**
+     * @var int
+     */
+    private $subunits;
 
     /**
      * @param \NumberFormatter $formatter
+     * @param int              $subunits
      */
-    public function __construct(\NumberFormatter $formatter)
+    public function __construct(\NumberFormatter $formatter, $subunits = 0)
     {
+        if (is_int($subunits) === false) {
+            throw new \InvalidArgumentException('Subunits must be an integer');
+        }
+
         $this->formatter = $formatter;
+        $this->subunits = $subunits;
     }
 
     /**
@@ -38,20 +48,19 @@ final class IntlMoneyFormatter implements MoneyFormatter
             $valueBase = substr($valueBase, 1);
         }
 
-        $fractionDigits = $this->formatter->getAttribute(\NumberFormatter::FRACTION_DIGITS);
         $valueLength = strlen($valueBase);
 
-        if ($valueLength > $fractionDigits) {
-            $subunits = substr($valueBase, 0, $valueLength - $fractionDigits).'.';
-            $subunits .= substr($valueBase, $valueLength - $fractionDigits);
+        if ($valueLength > $this->subunits) {
+            $number = substr($valueBase, 0, $valueLength - $this->subunits).'.';
+            $number .= substr($valueBase, $valueLength - $this->subunits);
         } else {
-            $subunits = '0.'.str_pad('', $fractionDigits - $valueLength, '0').$valueBase;
+            $number = '0.'.str_pad('', $this->subunits - $valueLength, '0').$valueBase;
         }
 
         if ($negative === true) {
-            $subunits = '-'.$subunits;
+            $number = '-'.$number;
         }
 
-        return $this->formatter->formatCurrency($subunits, $money->getCurrency()->getCode());
+        return $this->formatter->formatCurrency($number, $money->getCurrency()->getCode());
     }
 }

--- a/tests/Formatter/IntlMoneyFormatterTest.php
+++ b/tests/Formatter/IntlMoneyFormatterTest.php
@@ -11,8 +11,16 @@ final class IntlMoneyFormatterTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider numberFormatterExamples
      */
-    public function testNumberFormatter($amount, $currency, $result, $locale, $mode, $hasPattern, $fractionDigits)
-    {
+    public function testNumberFormatter(
+        $amount,
+        $currency,
+        $result,
+        $locale,
+        $mode,
+        $hasPattern,
+        $fractionDigits,
+        $subunits
+    ) {
         $money = new Money($amount, new Currency($currency));
 
         $numberFormatter = new \NumberFormatter($locale, $mode);
@@ -23,31 +31,32 @@ final class IntlMoneyFormatterTest extends \PHPUnit_Framework_TestCase
 
         $numberFormatter->setAttribute(\NumberFormatter::FRACTION_DIGITS, $fractionDigits);
 
-        $moneyFormatter = new IntlMoneyFormatter($numberFormatter);
+        $moneyFormatter = new IntlMoneyFormatter($numberFormatter, $subunits);
         $this->assertEquals($result, $moneyFormatter->format($money));
     }
 
     public static function numberFormatterExamples()
     {
         return [
-            [100, 'USD', '$1.00', 'en_US', \NumberFormatter::CURRENCY, true, 2],
-            [41, 'USD', '$0.41', 'en_US', \NumberFormatter::CURRENCY, true, 2],
-            [5, 'USD', '$0.05', 'en_US', \NumberFormatter::CURRENCY, true, 2],
-            [5, 'USD', '$0.005', 'en_US', \NumberFormatter::CURRENCY, true, 3],
-            [35, 'USD', '$0.035', 'en_US', \NumberFormatter::CURRENCY, true, 3],
-            [135, 'USD', '$0.135', 'en_US', \NumberFormatter::CURRENCY, true, 3],
-            [6135, 'USD', '$6.135', 'en_US', \NumberFormatter::CURRENCY, true, 3],
-            [-6135, 'USD', '-$6.135', 'en_US', \NumberFormatter::CURRENCY, true, 3],
-            [5, 'EUR', '€0.05', 'en_US', \NumberFormatter::CURRENCY, true, 2],
-            [50, 'EUR', '€0.50', 'en_US', \NumberFormatter::CURRENCY, true, 2],
-            [500, 'EUR', '€5.00', 'en_US', \NumberFormatter::CURRENCY, true, 2],
-            [5, 'EUR', '€0.05', 'en_US', \NumberFormatter::DECIMAL, true, 2],
-            [50, 'EUR', '€0.50', 'en_US', \NumberFormatter::DECIMAL, true, 2],
-            [500, 'EUR', '€5.00', 'en_US', \NumberFormatter::DECIMAL, true, 2],
-            [5, 'EUR', '5', 'en_US', \NumberFormatter::DECIMAL, false, 0],
-            [50, 'EUR', '50', 'en_US', \NumberFormatter::DECIMAL, false, 0],
-            [500, 'EUR', '500', 'en_US', \NumberFormatter::DECIMAL, false, 0],
-            [5, 'EUR', '500%', 'en_US', \NumberFormatter::PERCENT, false, 0],
+            [100, 'USD', '$1.00', 'en_US', \NumberFormatter::CURRENCY, true, 2, 2],
+            [41, 'USD', '$0.41', 'en_US', \NumberFormatter::CURRENCY, true, 2, 2],
+            [5, 'USD', '$0.05', 'en_US', \NumberFormatter::CURRENCY, true, 2, 2],
+            [5, 'USD', '$0.005', 'en_US', \NumberFormatter::CURRENCY, true, 3, 3],
+            [35, 'USD', '$0.035', 'en_US', \NumberFormatter::CURRENCY, true, 3, 3],
+            [135, 'USD', '$0.135', 'en_US', \NumberFormatter::CURRENCY, true, 3, 3],
+            [6135, 'USD', '$6.135', 'en_US', \NumberFormatter::CURRENCY, true, 3, 3],
+            [-6135, 'USD', '-$6.135', 'en_US', \NumberFormatter::CURRENCY, true, 3, 3],
+            [5, 'EUR', '€0.05', 'en_US', \NumberFormatter::CURRENCY, true, 2, 2],
+            [50, 'EUR', '€0.50', 'en_US', \NumberFormatter::CURRENCY, true, 2, 2],
+            [500, 'EUR', '€5.00', 'en_US', \NumberFormatter::CURRENCY, true, 2, 2],
+            [5, 'EUR', '€0.05', 'en_US', \NumberFormatter::DECIMAL, true, 2, 2],
+            [50, 'EUR', '€0.50', 'en_US', \NumberFormatter::DECIMAL, true, 2, 2],
+            [500, 'EUR', '€5.00', 'en_US', \NumberFormatter::DECIMAL, true, 2, 2],
+            [5, 'EUR', '5', 'en_US', \NumberFormatter::DECIMAL, false, 0, 0],
+            [50, 'EUR', '50', 'en_US', \NumberFormatter::DECIMAL, false, 0, 0],
+            [500, 'EUR', '500', 'en_US', \NumberFormatter::DECIMAL, false, 0, 0],
+            [5, 'EUR', '500%', 'en_US', \NumberFormatter::PERCENT, false, 0, 0],
+            [500, 'EUR', '5', 'en_US', \NumberFormatter::DECIMAL, false, 0, 2],
         ];
     }
 }


### PR DESCRIPTION
With the extra argument the user of formatter can now also control the number of subunits for a currency. This is fundamentally different than the amount fraction digits to be displayed (presentation vs business rule). It is optional because in the majority of the cases the subunits will equal the number of fraction digits.