### PR TITLE
Cast amount to integer on JSON conversion.

### DIFF
--- a/src/Money.php
+++ b/src/Money.php
@@ -442,7 +442,7 @@ final class Money implements \JsonSerializable
     public function jsonSerialize()
     {
         return [
-            'amount' => $this->amount,
+            'amount' => (int) $this->amount,
             'currency' => $this->currency,
         ];
     }

--- a/tests/MoneyTest.php
+++ b/tests/MoneyTest.php
@@ -23,7 +23,7 @@ final class MoneyTest extends \PHPUnit_Framework_TestCase
     public function testJsonEncoding()
     {
         $this->assertEquals(
-            '{"amount":"350","currency":"EUR"}',
+            '{"amount":350,"currency":"EUR"}',
             json_encode(Money::EUR(350))
         );
     }


### PR DESCRIPTION
The amount can be losslessly converted to an integer on the JSON output. This will provide the best experience to developers building APIs using the money object since their users won't need to cast the output on their end.