### PR TITLE
Added number of sub-units into Currency object, Money::fromFloat introduced

### DIFF
--- a/src/Calculator.php
+++ b/src/Calculator.php
@@ -105,4 +105,12 @@ interface Calculator
      * @return string
      */
     public function share($amount, $ratio, $total);
+
+    /**
+     * @param string $base
+     * @param string $exponent
+     *
+     * @return string
+     */
+    public function pow($base, $exponent);
 }

--- a/src/Calculator/BcMathCalculator.php
+++ b/src/Calculator/BcMathCalculator.php
@@ -217,4 +217,12 @@ final class BcMathCalculator implements Calculator
     {
         return $this->floor(bcdiv(bcmul($amount, $ratio, $this->scale), $total, $this->scale));
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function pow($base, $exponent)
+    {
+        return bcpow($base, $exponent, $this->scale);
+    }
 }

--- a/src/Calculator/GmpCalculator.php
+++ b/src/Calculator/GmpCalculator.php
@@ -216,4 +216,12 @@ final class GmpCalculator implements Calculator
     {
         return $this->floor($this->divide($this->multiply($amount, $ratio), $total));
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function pow($base, $exponent)
+    {
+        return gmp_pow($base, $exponent);
+    }
 }

--- a/src/Calculator/PhpCalculator.php
+++ b/src/Calculator/PhpCalculator.php
@@ -170,4 +170,12 @@ final class PhpCalculator implements Calculator
             throw new \UnexpectedValueException('The result of arithmetic operation is not an integer');
         }
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function pow($base, $exponent)
+    {
+        return (string) pow($base, $exponent);
+    }
 }

--- a/src/Currency.php
+++ b/src/Currency.php
@@ -11,6 +11,8 @@ namespace Money;
  */
 final class Currency implements \JsonSerializable
 {
+    const DEFAULT_NUMBER_OF_SUBUNITS = 2;
+
     /**
      * Currency code.
      *
@@ -19,15 +21,22 @@ final class Currency implements \JsonSerializable
     private $code;
 
     /**
-     * @param string $code
+     * @var int
      */
-    public function __construct($code)
+    private $numberOfSubUnits;
+
+    /**
+     * @param string $code
+     * @param int    $numberOfSubUnits
+     */
+    public function __construct($code, $numberOfSubUnits = self::DEFAULT_NUMBER_OF_SUBUNITS)
     {
         if (!is_string($code)) {
             throw new \InvalidArgumentException('Currency code should be string');
         }
 
         $this->code = $code;
+        $this->numberOfSubUnits = $numberOfSubUnits;
     }
 
     /**
@@ -80,5 +89,13 @@ final class Currency implements \JsonSerializable
     public function jsonSerialize()
     {
         return $this->code;
+    }
+
+    /**
+     * @return int
+     */
+    public function getNumberOfSubUnits()
+    {
+        return $this->numberOfSubUnits;
     }
 }

--- a/src/Money.php
+++ b/src/Money.php
@@ -61,6 +61,27 @@ final class Money implements \JsonSerializable
     }
 
     /**
+     * @param float|string $amount
+     * @param Currency     $currency
+     *
+     * @return static
+     */
+    public static function fromFloat($amount, Currency $currency)
+    {
+        if (!is_numeric($amount)) {
+            throw new \InvalidArgumentException('Amount must be a number.');
+        }
+
+        $calculator = self::getCalculator();
+        $amount = $calculator->multiply(
+            (string) $amount,
+            $calculator->pow('10', (string) $currency->getNumberOfSubUnits())
+        );
+
+        return new static(self::normalize($amount), $currency);
+    }
+
+    /**
      * Convenience factory method for a Money object.
      *
      * <code>
@@ -144,7 +165,7 @@ final class Money implements \JsonSerializable
     {
         $this->assertSameCurrency($other);
 
-        return $this->getCalculator()->compare($this->amount, $other->amount);
+        return self::getCalculator()->compare($this->amount, $other->amount);
     }
 
     /**
@@ -223,7 +244,7 @@ final class Money implements \JsonSerializable
     {
         $this->assertSameCurrency($addend);
 
-        return new self($this->getCalculator()->add($this->amount, $addend->amount), $this->currency);
+        return new self(self::getCalculator()->add($this->amount, $addend->amount), $this->currency);
     }
 
     /**
@@ -238,7 +259,7 @@ final class Money implements \JsonSerializable
     {
         $this->assertSameCurrency($subtrahend);
 
-        return new self($this->getCalculator()->subtract($this->amount, $subtrahend->amount), $this->currency);
+        return new self(self::getCalculator()->subtract($this->amount, $subtrahend->amount), $this->currency);
     }
 
     /**
@@ -297,7 +318,7 @@ final class Money implements \JsonSerializable
         $this->assertOperand($multiplier);
         $this->assertRoundingMode($roundingMode);
 
-        $product = $this->round($this->getCalculator()->multiply($this->amount, $multiplier), $roundingMode);
+        $product = $this->round(self::getCalculator()->multiply($this->amount, $multiplier), $roundingMode);
 
         return $this->newInstance($product);
     }
@@ -312,7 +333,7 @@ final class Money implements \JsonSerializable
     public function convert(Currency $targetCurrency, $conversionRate, $roundingMode = self::ROUND_HALF_UP)
     {
         $this->assertRoundingMode($roundingMode);
-        $amount = $this->getCalculator()->round($this->getCalculator()->multiply($this->amount, $conversionRate), $roundingMode);
+        $amount = self::getCalculator()->round(self::getCalculator()->multiply($this->amount, $conversionRate), $roundingMode);
 
         return new self($amount, $targetCurrency);
     }
@@ -331,11 +352,11 @@ final class Money implements \JsonSerializable
         $this->assertOperand($divisor);
         $this->assertRoundingMode($roundingMode);
 
-        if ($this->getCalculator()->compare((string) $divisor, '0') === 0) {
+        if (self::getCalculator()->compare((string) $divisor, '0') === 0) {
             throw new \InvalidArgumentException('Division by zero');
         }
 
-        $quotient = $this->round($this->getCalculator()->divide($this->amount, $divisor), $roundingMode);
+        $quotient = $this->round(self::getCalculator()->divide($this->amount, $divisor), $roundingMode);
 
         return $this->newInstance($quotient);
     }
@@ -354,14 +375,14 @@ final class Money implements \JsonSerializable
         $total = array_sum($ratios);
 
         foreach ($ratios as $ratio) {
-            $share = $this->getCalculator()->share($this->amount, $ratio, $total);
+            $share = self::getCalculator()->share($this->amount, $ratio, $total);
             $results[] = $this->newInstance($share);
-            $remainder = $this->getCalculator()->subtract($remainder, $share);
+            $remainder = self::getCalculator()->subtract($remainder, $share);
         }
 
-        for ($i = 0; $this->getCalculator()->compare($remainder, 0) === 1; ++$i) {
-            $results[$i]->amount = $this->getCalculator()->add($results[$i]->amount, 1);
-            $remainder = $this->getCalculator()->subtract($remainder, 1);
+        for ($i = 0; self::getCalculator()->compare($remainder, 0) === 1; ++$i) {
+            $results[$i]->amount = self::getCalculator()->add($results[$i]->amount, 1);
+            $remainder = self::getCalculator()->subtract($remainder, 1);
         }
 
         return $results;
@@ -395,13 +416,13 @@ final class Money implements \JsonSerializable
     {
         $this->assertRoundingMode($rounding_mode);
         if ($rounding_mode === self::ROUND_UP) {
-            return $this->getCalculator()->ceil($amount);
+            return self::getCalculator()->ceil($amount);
         }
         if ($rounding_mode === self::ROUND_DOWN) {
-            return $this->getCalculator()->floor($amount);
+            return self::getCalculator()->floor($amount);
         }
 
-        return $this->getCalculator()->round($amount, $rounding_mode);
+        return self::getCalculator()->round($amount, $rounding_mode);
     }
 
     /**
@@ -411,7 +432,7 @@ final class Money implements \JsonSerializable
      */
     public function isZero()
     {
-        return 0 === $this->getCalculator()->compare($this->amount, 0);
+        return 0 === self::getCalculator()->compare($this->amount, 0);
     }
 
     /**
@@ -421,7 +442,7 @@ final class Money implements \JsonSerializable
      */
     public function isPositive()
     {
-        return 1 === $this->getCalculator()->compare($this->amount, 0);
+        return 1 === self::getCalculator()->compare($this->amount, 0);
     }
 
     /**
@@ -431,7 +452,7 @@ final class Money implements \JsonSerializable
      */
     public function isNegative()
     {
-        return -1 === $this->getCalculator()->compare($this->amount, 0);
+        return -1 === self::getCalculator()->compare($this->amount, 0);
     }
 
     /**
@@ -480,12 +501,47 @@ final class Money implements \JsonSerializable
     /**
      * @return Calculator
      */
-    private function getCalculator()
+    private static function getCalculator()
     {
         if (self::$calculator === null) {
             self::$calculator = self::initializeCalculator();
         }
 
         return self::$calculator;
+    }
+
+    /**
+     * @return string
+     */
+    public function __toString()
+    {
+        $calculator = self::getCalculator();
+
+        $amount = $calculator->divide(
+            $this->amount,
+            $calculator->pow('10', (string) $this->currency->getNumberOfSubUnits())
+        );
+
+        return sprintf('%s %s', self::normalize($amount), $this->currency->getCode());
+    }
+
+    /**
+     * @param string $number
+     *
+     * @return string
+     */
+    public static function normalize($number)
+    {
+        if (strpos($number, '.') !== false) {
+            $number = trim($number, '0');
+            if ($number[0] === '.') {
+                $number = '0'.$number;
+            }
+            if ($number[strlen($number) - 1] === '.') {
+                $number = substr($number, 0, strlen($number) - 1);
+            }
+        }
+
+        return $number;
     }
 }

--- a/tests/MoneyTest.php
+++ b/tests/MoneyTest.php
@@ -36,4 +36,68 @@ final class MoneyTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Money\\Money', (new Money(PHP_INT_MAX, new Currency('EUR')))->add($one));
         $this->assertInstanceOf('Money\\Money', (new Money(PHP_INT_MAX, new Currency('EUR')))->subtract($one));
     }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testCreateFromFloatError()
+    {
+        Money::fromFloat('1.23456789', new Currency('XXX', 2));
+    }
+
+    /**
+     * @dataProvider getDataForNormalize
+     *
+     * @param string $expected
+     * @param string $input
+     */
+    public function testNormalize($expected, $input)
+    {
+        self::assertEquals($expected, Money::normalize($input));
+    }
+
+    /**
+     * @return array
+     */
+    public function getDataForNormalize()
+    {
+        return [
+            ['0', '0'],
+            ['10', '10'],
+            ['1', '1'],
+            ['1', '1.'],
+            ['0.1', '.1'],
+            ['0', '.'],
+            ['0', '00.00'],
+        ];
+    }
+
+    /**
+     * @dataProvider getDataForCreateFromFloat
+     *
+     * @param string       $expected
+     * @param string|float $amount
+     * @param int          $numberOfSubunits
+     */
+    public function testCreateFromFloat($expected, $amount, $numberOfSubunits)
+    {
+        $money = Money::fromFloat($amount, new Currency('XXX', $numberOfSubunits));
+
+        self::assertEquals($expected, (string) $money);
+    }
+
+    /**
+     * @return array
+     */
+    public function getDataForCreateFromFloat()
+    {
+        return [
+            ['1 XXX', 1, 0],
+            ['1 XXX', 1.0, 0],
+            ['1 XXX', '1.0', 0],
+
+            ['1.23456789 XXX', '1.23456789', 10],
+            ['-1.23456789 XXX', '-1.23456789', 10],
+        ];
+    }
 }


### PR DESCRIPTION
Hello, here is my small change. 
* I'd like to introduce `numberOfSubunits` into `Currency` object.
* The purpose for this is ability to create Money object from alternative construct method `Money::fromFloat()`.
 * Usages for this method can be: 
   * Parsing user input into `Money` object.
    * Create `Money` object for Crypto-currencies like bitcoin (Satoshi, `numberOfSubunits => 8`) or Ethereum (Theter, `numberOfSubunits = 12`), etc...

I also:
* Added `__toString` method for `Money` (mainly for test and development reasons - I found it handy.)
* Added `Money::normalize` to make strings like `1.000000` to `1`. (Necesary for `__toString()`)
* Added `pow` method for (`10^n`) into Calculator interfaces and all implementations.

Under the hood:
* I made `getCalculator()` method static to be usable in alternative static constructors (`fromFloat`). Also, because it works only with static properties, I think it should be static anyway.

Thanks for your review and comments. 