### PR TITLE
bug fix: cannot allocate to none

### DIFF
--- a/spec/MoneySpec.php
+++ b/spec/MoneySpec.php
@@ -351,6 +351,16 @@ class MoneySpec extends ObjectBehavior
         $this->shouldThrow(\InvalidArgumentException::class)->duringAllocateTo('two');
     }
 
+    function it_throws_an_exception_when_allocate_target_is_empty()
+    {
+        $this->shouldThrow(\InvalidArgumentException::class)->duringAllocate([]);
+    }
+
+    function it_throws_an_exception_when_allocate_to_target_is_less_than_equals_zero()
+    {
+        $this->shouldThrow(\InvalidArgumentException::class)->duringAllocateTo(-1);
+    }
+
     /**
      * @dataProvider comparatorExamples
      */

--- a/src/Exchange.php
+++ b/src/Exchange.php
@@ -19,7 +19,7 @@ interface Exchange
      *
      * @return CurrencyPair
      *
-     * @throws UnresolvableCurrencyPairException When there is no currency pair (rate) available for the given currencies.
+     * @throws UnresolvableCurrencyPairException When there is no currency pair (rate) available for the given currencies
      */
     public function getCurrencyPair(Currency $baseCurrency, Currency $counterCurrency);
 }

--- a/src/Money.php
+++ b/src/Money.php
@@ -349,6 +349,9 @@ final class Money implements \JsonSerializable
      */
     public function allocate(array $ratios)
     {
+        if (count($ratios) === 0) {
+            throw new \InvalidArgumentException('Cannot allocate to none');
+        }
         $remainder = $this->amount;
         $results = [];
         $total = array_sum($ratios);
@@ -380,6 +383,10 @@ final class Money implements \JsonSerializable
     {
         if (!is_int($n)) {
             throw new \InvalidArgumentException('Number of targets must be an integer');
+        }
+
+        if ($n <= 0) {
+            throw new \InvalidArgumentException('Cannot allocate to none');
         }
 
         return $this->allocate(array_fill(0, $n, 1));


### PR DESCRIPTION
Prevent PHP errors when the allocation array does not contain any elements: either via `allocate` or via `allocateTo`.