### PR TITLE
Switch iso currencies source

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,12 +28,12 @@
         "ext-gmp": "*",
         "ext-intl": "*",
         "florianv/swap": "^2.3",
-        "umpirsky/currency-list": "^1.0",
         "psr/cache": "^1.0",
         "cache/taggable-cache": "^0.4.0",
         "phpspec/phpspec": "^2.5",
         "henrikbjorn/phpspec-code-coverage": "^2.0.2",
-        "coduo/phpspec-data-provider-extension": "^1.0.3"
+        "coduo/phpspec-data-provider-extension": "^1.0.3",
+        "moneyphp/iso-currencies": "dev-master"
     },
     "suggest": {
         "ext-bcmath": "Calculate without integer limits",

--- a/spec/Currencies/ISOCurrenciesSpec.php
+++ b/spec/Currencies/ISOCurrenciesSpec.php
@@ -28,7 +28,7 @@ class ISOCurrenciesSpec extends ObjectBehavior
 
     public function currencyCodeExamples()
     {
-        $currencies = require __DIR__.'/../../resources/currency.php';
+        $currencies = require __DIR__.'/../../vendor/moneyphp/iso-currencies/resources/current.php';
         $currencies = array_keys($currencies);
 
         return array_map(function($currency) { return [$currency]; }, $currencies);

--- a/src/Currencies/ISOCurrencies.php
+++ b/src/Currencies/ISOCurrencies.php
@@ -28,12 +28,12 @@ final class ISOCurrencies implements Currencies
             self::$currencies = $this->loadCurrencies();
         }
 
-        return array_key_exists($currency->getCode(), self::$currencies);
+        return isset(self::$currencies[$currency->getCode()]);
     }
 
     private function loadCurrencies()
     {
-        $file = __DIR__.'/../../resources/currency.php';
+        $file = __DIR__.'/../../vendor/moneyphp/iso-currencies/resources/current.php';
 
         if (file_exists($file)) {
             return require $file;


### PR DESCRIPTION
Switch umpirsky/currency-list for our own moneyphp/iso-currenciesto to be used in ISOCurrencies. That means we are using official ISO repository now. Also fixes #235 and #243.