### PR TITLE
Extend currencies with subunit

### DIFF
--- a/spec/Currencies/AggregateCurrenciesSpec.php
+++ b/spec/Currencies/AggregateCurrenciesSpec.php
@@ -9,6 +9,8 @@ use Prophecy\Argument;
 
 class AggregateCurrenciesSpec extends ObjectBehavior
 {
+    use HaveCurrencyTrait;
+
     function let(Currencies $isoCurrencies, Currencies $otherCurrencies)
     {
         $this->beConstructedWith([
@@ -35,7 +37,17 @@ class AggregateCurrenciesSpec extends ObjectBehavior
         $this->contains(new Currency('EUR'))->shouldReturn(true);
     }
 
-    function testItDoesNotContainCurrencies()
+    function it_can_be_iterated(Currencies $isoCurrencies, Currencies $otherCurrencies)
+    {
+        $isoCurrencies->getIterator()->willReturn(new \ArrayIterator(['EUR']));
+        $otherCurrencies->getIterator()->willReturn(new \ArrayIterator(['USD']));
+
+        $this->getIterator()->shouldReturnAnInstanceOf(\Traversable::class);
+        $this->getIterator()->shouldHaveCurrency('EUR');
+        $this->getIterator()->shouldHaveCurrency('USD');
+    }
+
+    function testItDoesNotContainCurrencies(Currencies $isoCurrencies, Currencies $otherCurrencies)
     {
         $isoCurrencies->contains(Argument::type(Currency::class))->willReturn(false);
         $otherCurrencies->contains(Argument::type(Currency::class))->willReturn(true);

--- a/spec/Currencies/BitcoinCurrenciesSpec.php
+++ b/spec/Currencies/BitcoinCurrenciesSpec.php
@@ -9,6 +9,8 @@ use Prophecy\Argument;
 
 class BitcoinCurrenciesSpec extends ObjectBehavior
 {
+    use HaveCurrencyTrait;
+
     function it_is_initializable()
     {
         $this->shouldHaveType('Money\Currencies\BitcoinCurrencies');
@@ -23,5 +25,11 @@ class BitcoinCurrenciesSpec extends ObjectBehavior
     {
         $this->contains(new Currency('XBT'))->shouldReturn(true);
         $this->contains(new Currency('EUR'))->shouldReturn(false);
+    }
+
+    function it_can_be_iterated()
+    {
+        $this->getIterator()->shouldReturnAnInstanceOf(\Traversable::class);
+        $this->getIterator()->shouldHaveCurrency('XBT');
     }
 }

--- a/spec/Currencies/CachedCurrenciesSpec.php
+++ b/spec/Currencies/CachedCurrenciesSpec.php
@@ -11,6 +11,8 @@ use Prophecy\Argument;
 
 class CachedCurrenciesSpec extends ObjectBehavior
 {
+    use HaveCurrencyTrait;
+
     function let(Currencies $currencies, CacheItemPoolInterface $pool)
     {
         $this->beConstructedWith($currencies, $pool);
@@ -58,5 +60,20 @@ class CachedCurrenciesSpec extends ObjectBehavior
         $currencies->contains(Argument::type(Currency::class))->shouldNotBeCalled();
 
         $this->contains(new Currency('EUR'))->shouldReturn(true);
+    }
+
+    function it_can_be_iterated(
+        CacheItemInterface $item,
+        CacheItemPoolInterface $pool,
+        Currencies $currencies
+    ) {
+        $item->set(true)->shouldBeCalled();
+        $pool->save($item)->shouldBeCalled();
+
+        $pool->getItem('currency|availability|EUR')->willReturn($item);
+        $currencies->getIterator()->willReturn(new \ArrayIterator(['EUR']));
+
+        $this->getIterator()->shouldReturnAnInstanceOf(\Traversable::class);
+        $this->getIterator()->shouldHaveCurrency('EUR');
     }
 }

--- a/spec/Currencies/HaveCurrencyTrait.php
+++ b/spec/Currencies/HaveCurrencyTrait.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace spec\Money\Currencies;
+
+trait HaveCurrencyTrait
+{
+    /**
+     * @return array
+     */
+    public function getMatchers()
+    {
+        return [
+            'haveCurrency' => function ($subject, $value) {
+                foreach ($subject as $code) {
+                    if ($code === $value) {
+                        return true;
+                    }
+                }
+
+                return false;
+            },
+        ];
+    }
+}

--- a/spec/Currencies/ISOCurrenciesSpec.php
+++ b/spec/Currencies/ISOCurrenciesSpec.php
@@ -4,10 +4,13 @@ namespace spec\Money\Currencies;
 
 use Money\Currencies;
 use Money\Currency;
+use Money\Exception\UnknownCurrencyException;
 use PhpSpec\ObjectBehavior;
 
 class ISOCurrenciesSpec extends ObjectBehavior
 {
+    use HaveCurrencyTrait;
+
     function it_is_initializable()
     {
         $this->shouldHaveType('Money\Currencies\ISOCurrencies');
@@ -24,6 +27,25 @@ class ISOCurrenciesSpec extends ObjectBehavior
     function it_contains_iso_currencies($currency)
     {
         $this->contains(new Currency($currency))->shouldReturn(true);
+    }
+
+    /**
+     * @dataProvider currencyCodeExamples
+     */
+    function it_has_a_subunit($currency)
+    {
+        $this->subunitFor(new Currency($currency))->shouldBeInteger();
+    }
+
+    function it_throws_an_exception_when_currency_is_unknown()
+    {
+        $this->shouldThrow(UnknownCurrencyException::class)->duringSubunitFor(new Currency('XXXX'));
+    }
+
+    function it_provides_an_iterator()
+    {
+        $this->getIterator()->shouldReturnAnInstanceOf(\Traversable::class);
+        $this->getIterator()->shouldHaveCurrency('EUR');
     }
 
     public function currencyCodeExamples()

--- a/spec/Formatter/BitcoinMoneyFormatterSpec.php
+++ b/spec/Formatter/BitcoinMoneyFormatterSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\Money\Formatter;
 
+use Money\Currencies;
 use Money\Currency;
 use Money\Exception\FormatterException;
 use Money\Money;
@@ -11,9 +12,9 @@ use Prophecy\Argument;
 
 class BitcoinMoneyFormatterSpec extends ObjectBehavior
 {
-    function let()
+    function let(Currencies $bitcoinCurrencies)
     {
-        $this->beConstructedWith(2);
+        $this->beConstructedWith(2, $bitcoinCurrencies);
     }
 
     function it_is_initializable()
@@ -29,23 +30,29 @@ class BitcoinMoneyFormatterSpec extends ObjectBehavior
     /**
      * @dataProvider bitcoinExamples
      */
-    function it_formats_money($value, $formatted, $fractionDigits)
+    function it_formats_money($value, $formatted, $fractionDigits, Currencies $bitcoinCurrencies)
     {
-        $this->beConstructedWith($fractionDigits);
+        $this->beConstructedWith($fractionDigits, $bitcoinCurrencies);
 
-        $money = new Money($value, new Currency('XBT'));
+        $currency = new Currency('XBT');
+        $money = new Money($value, $currency);
 
+        $bitcoinCurrencies->subunitFor($currency)->willReturn(8);
         $this->format($money)->shouldReturn($formatted);
     }
 
     public function bitcoinExamples()
     {
         return [
-            [100000, "\0xC9\0x831000.00", 2],
-            [41, "\0xC9\0x830.41", 2],
-            [5, "\0xC9\0x830.05", 2],
-            [5, "\0xC9\0x835", 0],
-            [5, "\0xC9\0x830.0005", 4],
+            [100000000000, "\0xC9\0x831000.00", 2],
+            [1000000000000, "\0xC9\0x8310000.00", 2],
+            [41000000, "\0xC9\0x830.41", 2],
+            [5000000, "\0xC9\0x830.05", 2],
+            [500000000, "\0xC9\0x835", 0],
+            [50000, "\0xC9\0x830.0005", 4],
+            [100000500000, "\0xC9\0x831000.01", 2],
+            [100099500000, "\0xC9\0x831001.00", 2],
+            [999999600000, "\0xC9\0x8310000.00", 2],
         ];
     }
 

--- a/spec/Formatter/IntlMoneyFormatterSpec.php
+++ b/spec/Formatter/IntlMoneyFormatterSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\Money\Formatter;
 
+use Money\Currencies;
 use Money\Currency;
 use Money\Money;
 use Money\MoneyFormatter;
@@ -9,9 +10,9 @@ use PhpSpec\ObjectBehavior;
 
 class IntlMoneyFormatterSpec extends ObjectBehavior
 {
-    function let(\NumberFormatter $numberFormatter)
+    function let(\NumberFormatter $numberFormatter, Currencies $currencies)
     {
-        $this->beConstructedWith($numberFormatter);
+        $this->beConstructedWith($numberFormatter, $currencies);
     }
 
     function it_is_initializable()
@@ -24,12 +25,12 @@ class IntlMoneyFormatterSpec extends ObjectBehavior
         $this->shouldImplement(MoneyFormatter::class);
     }
 
-    function it_formats_money(\NumberFormatter $numberFormatter)
+    function it_formats_money(\NumberFormatter $numberFormatter, Currencies $currencies)
     {
-        $numberFormatter->getAttribute(\NumberFormatter::FRACTION_DIGITS)->willReturn(2);
-        $numberFormatter->formatCurrency('0.01', 'EUR')->willReturn('€1.00');
-
         $money = new Money(1, new Currency('EUR'));
+
+        $numberFormatter->formatCurrency('0.01', 'EUR')->willReturn('€1.00');
+        $currencies->subunitFor($money->getCurrency())->willReturn(2);
 
         $this->format($money)->shouldReturn('€1.00');
     }

--- a/src/Currencies.php
+++ b/src/Currencies.php
@@ -2,12 +2,14 @@
 
 namespace Money;
 
+use Money\Exception\UnknownCurrencyException;
+
 /**
  * Implement this to provide a list of currencies.
  *
  * @author Mathias Verraes
  */
-interface Currencies
+interface Currencies extends \IteratorAggregate
 {
     /**
      * Checks whether a currency is available in the current context.
@@ -17,4 +19,15 @@ interface Currencies
      * @return bool
      */
     public function contains(Currency $currency);
+
+    /**
+     * Returns the subunit for a currency.
+     *
+     * @param Currency $currency
+     *
+     * @return int
+     *
+     * @throws UnknownCurrencyException
+     */
+    public function subunitFor(Currency $currency);
 }

--- a/src/Currencies/AggregateCurrencies.php
+++ b/src/Currencies/AggregateCurrencies.php
@@ -4,6 +4,7 @@ namespace Money\Currencies;
 
 use Money\Currencies;
 use Money\Currency;
+use Money\Exception\UnknownCurrencyException;
 
 /**
  * Aggregates several currency repositories.
@@ -43,5 +44,34 @@ final class AggregateCurrencies implements Currencies
         }
 
         return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function subunitFor(Currency $currency)
+    {
+        foreach ($this->currencies as $c) {
+            try {
+                return $c->subunitFor($currency);
+            } catch (UnknownCurrencyException $e) {
+            }
+        }
+
+        throw new UnknownCurrencyException('Cannot find currency '.$currency->getCode());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getIterator()
+    {
+        $iterator = new \AppendIterator();
+
+        foreach ($this->currencies as $c) {
+            $iterator->append($c->getIterator());
+        }
+
+        return $iterator;
     }
 }

--- a/src/Currencies/BitcoinCurrencies.php
+++ b/src/Currencies/BitcoinCurrencies.php
@@ -20,4 +20,20 @@ final class BitcoinCurrencies implements Currencies
     {
         return self::CODE === $currency->getCode();
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function subunitFor(Currency $currency)
+    {
+        return 8;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getIterator()
+    {
+        return new \ArrayIterator([self::CODE]);
+    }
 }

--- a/src/Currencies/CachedCurrencies.php
+++ b/src/Currencies/CachedCurrencies.php
@@ -53,4 +53,46 @@ final class CachedCurrencies implements Currencies
 
         return $item->get();
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function subunitFor(Currency $currency)
+    {
+        $item = $this->pool->getItem('currency|subunit|'.$currency->getCode());
+
+        if (false === $item->isHit()) {
+            $item->set($this->currencies->subunitFor($currency));
+
+            if ($item instanceof TaggableItemInterface) {
+                $item->addTag('currency.subunit');
+            }
+
+            $this->pool->save($item);
+        }
+
+        return $item->get();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getIterator()
+    {
+        return new \CallbackFilterIterator(
+            $this->currencies->getIterator(),
+            function ($currencyCode) {
+                $item = $this->pool->getItem('currency|availability|'.$currencyCode);
+                $item->set(true);
+
+                if ($item instanceof TaggableItemInterface) {
+                    $item->addTag('currency.availability');
+                }
+
+                $this->pool->save($item);
+
+                return true;
+            }
+        );
+    }
 }

--- a/src/Currencies/ISOCurrencies.php
+++ b/src/Currencies/ISOCurrencies.php
@@ -4,6 +4,7 @@ namespace Money\Currencies;
 
 use Money\Currencies;
 use Money\Currency;
+use Money\Exception\UnknownCurrencyException;
 
 /**
  * List of supported ISO 4217 currency codes and names.
@@ -31,6 +32,37 @@ final class ISOCurrencies implements Currencies
         return isset(self::$currencies[$currency->getCode()]);
     }
 
+    /**
+     * {@inheritdoc}
+     */
+    public function subunitFor(Currency $currency)
+    {
+        if (null === self::$currencies) {
+            self::$currencies = $this->loadCurrencies();
+        }
+
+        if (!isset(self::$currencies[$currency->getCode()])) {
+            throw new UnknownCurrencyException('Cannot find ISO currency '.$currency->getCode());
+        }
+
+        return self::$currencies[$currency->getCode()]['minorUnit'];
+    }
+
+    /**
+     * @return \Traversable
+     */
+    public function getIterator()
+    {
+        if (null === self::$currencies) {
+            self::$currencies = $this->loadCurrencies();
+        }
+
+        return new \ArrayIterator(array_keys(self::$currencies));
+    }
+
+    /**
+     * @return array
+     */
     private function loadCurrencies()
     {
         $file = __DIR__.'/../../vendor/moneyphp/iso-currencies/resources/current.php';

--- a/src/Exception/UnknownCurrencyException.php
+++ b/src/Exception/UnknownCurrencyException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Money\Exception;
+
+/**
+ * Thrown when trying to get ISO currency that does not exists.
+ *
+ * @author Frederik Bosch <f.bosch@genkgo.nl>
+ */
+final class UnknownCurrencyException extends \RuntimeException implements Exception
+{
+}

--- a/src/Formatter/IntlMoneyFormatter.php
+++ b/src/Formatter/IntlMoneyFormatter.php
@@ -2,6 +2,7 @@
 
 namespace Money\Formatter;
 
+use Money\Currencies;
 use Money\Money;
 use Money\MoneyFormatter;
 
@@ -16,13 +17,19 @@ final class IntlMoneyFormatter implements MoneyFormatter
      * @var \NumberFormatter
      */
     private $formatter;
+    /**
+     * @var Currencies
+     */
+    private $currencies;
 
     /**
      * @param \NumberFormatter $formatter
+     * @param Currencies       $currencies
      */
-    public function __construct(\NumberFormatter $formatter)
+    public function __construct(\NumberFormatter $formatter, Currencies $currencies)
     {
         $this->formatter = $formatter;
+        $this->currencies = $currencies;
     }
 
     /**
@@ -33,25 +40,25 @@ final class IntlMoneyFormatter implements MoneyFormatter
         $valueBase = (string) $money->getAmount();
         $negative = false;
 
-        if (substr($valueBase, 0, 1) === '-') {
+        if ($valueBase[0] === '-') {
             $negative = true;
             $valueBase = substr($valueBase, 1);
         }
 
-        $fractionDigits = $this->formatter->getAttribute(\NumberFormatter::FRACTION_DIGITS);
+        $subunit = $this->currencies->subunitFor($money->getCurrency());
         $valueLength = strlen($valueBase);
 
-        if ($valueLength > $fractionDigits) {
-            $subunits = substr($valueBase, 0, $valueLength - $fractionDigits).'.';
-            $subunits .= substr($valueBase, $valueLength - $fractionDigits);
+        if ($valueLength > $subunit) {
+            $formatted = substr($valueBase, 0, $valueLength - $subunit).'.';
+            $formatted .= substr($valueBase, $valueLength - $subunit);
         } else {
-            $subunits = '0.'.str_pad('', $fractionDigits - $valueLength, '0').$valueBase;
+            $formatted = '0.'.str_pad('', $subunit - $valueLength, '0').$valueBase;
         }
 
         if ($negative === true) {
-            $subunits = '-'.$subunits;
+            $formatted = '-'.$formatted;
         }
 
-        return $this->formatter->formatCurrency($subunits, $money->getCurrency()->getCode());
+        return $this->formatter->formatCurrency($formatted, $money->getCurrency()->getCode());
     }
 }

--- a/src/Number.php
+++ b/src/Number.php
@@ -178,4 +178,39 @@ final class Number
 
         return count($invalid) === 0;
     }
+
+    /**
+     * @param string $moneyValue
+     * @param int    $targetDigits
+     * @param int    $havingDigits
+     *
+     * @return string
+     */
+    public static function roundMoneyValue($moneyValue, $targetDigits, $havingDigits)
+    {
+        $valueLength = strlen($moneyValue);
+
+        if ($targetDigits < $havingDigits && $moneyValue[$valueLength - $havingDigits + $targetDigits] >= 5) {
+            $position = $valueLength - $havingDigits + $targetDigits;
+            $addend = 1;
+
+            while ($position > 0) {
+                $newValue = (string) ((int) $moneyValue[$position - 1] + $addend);
+
+                if ($newValue >= 10) {
+                    $moneyValue[$position - 1] = $newValue[1];
+                    $addend = $newValue[0];
+                    --$position;
+                    if ($position === 0) {
+                        $moneyValue = $addend.$moneyValue;
+                    }
+                } else {
+                    $moneyValue[$position - 1] = $newValue[0];
+                    break;
+                }
+            }
+        }
+
+        return $moneyValue;
+    }
 }

--- a/tests/Formatter/IntlMoneyFormatterTest.php
+++ b/tests/Formatter/IntlMoneyFormatterTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Money\Formatter;
 
+use Money\Currencies\ISOCurrencies;
 use Money\Currency;
 use Money\Formatter\IntlMoneyFormatter;
 use Money\Money;
@@ -11,11 +12,11 @@ final class IntlMoneyFormatterTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider numberFormatterExamples
      */
-    public function testNumberFormatter($amount, $currency, $result, $locale, $mode, $hasPattern, $fractionDigits)
+    public function testNumberFormatter($amount, $currency, $result, $mode, $hasPattern, $fractionDigits)
     {
         $money = new Money($amount, new Currency($currency));
 
-        $numberFormatter = new \NumberFormatter($locale, $mode);
+        $numberFormatter = new \NumberFormatter('en_US', $mode);
 
         if (true === $hasPattern) {
             $numberFormatter->setPattern('¤#,##0.00;-¤#,##0.00');
@@ -23,31 +24,34 @@ final class IntlMoneyFormatterTest extends \PHPUnit_Framework_TestCase
 
         $numberFormatter->setAttribute(\NumberFormatter::FRACTION_DIGITS, $fractionDigits);
 
-        $moneyFormatter = new IntlMoneyFormatter($numberFormatter);
+        $moneyFormatter = new IntlMoneyFormatter($numberFormatter, new ISOCurrencies());
         $this->assertEquals($result, $moneyFormatter->format($money));
     }
 
     public static function numberFormatterExamples()
     {
         return [
-            [100, 'USD', '$1.00', 'en_US', \NumberFormatter::CURRENCY, true, 2],
-            [41, 'USD', '$0.41', 'en_US', \NumberFormatter::CURRENCY, true, 2],
-            [5, 'USD', '$0.05', 'en_US', \NumberFormatter::CURRENCY, true, 2],
-            [5, 'USD', '$0.005', 'en_US', \NumberFormatter::CURRENCY, true, 3],
-            [35, 'USD', '$0.035', 'en_US', \NumberFormatter::CURRENCY, true, 3],
-            [135, 'USD', '$0.135', 'en_US', \NumberFormatter::CURRENCY, true, 3],
-            [6135, 'USD', '$6.135', 'en_US', \NumberFormatter::CURRENCY, true, 3],
-            [-6135, 'USD', '-$6.135', 'en_US', \NumberFormatter::CURRENCY, true, 3],
-            [5, 'EUR', '€0.05', 'en_US', \NumberFormatter::CURRENCY, true, 2],
-            [50, 'EUR', '€0.50', 'en_US', \NumberFormatter::CURRENCY, true, 2],
-            [500, 'EUR', '€5.00', 'en_US', \NumberFormatter::CURRENCY, true, 2],
-            [5, 'EUR', '€0.05', 'en_US', \NumberFormatter::DECIMAL, true, 2],
-            [50, 'EUR', '€0.50', 'en_US', \NumberFormatter::DECIMAL, true, 2],
-            [500, 'EUR', '€5.00', 'en_US', \NumberFormatter::DECIMAL, true, 2],
-            [5, 'EUR', '5', 'en_US', \NumberFormatter::DECIMAL, false, 0],
-            [50, 'EUR', '50', 'en_US', \NumberFormatter::DECIMAL, false, 0],
-            [500, 'EUR', '500', 'en_US', \NumberFormatter::DECIMAL, false, 0],
-            [5, 'EUR', '500%', 'en_US', \NumberFormatter::PERCENT, false, 0],
+            [5005, 'USD', '$50', \NumberFormatter::CURRENCY, true, 0],
+            [100, 'USD', '$1.00', \NumberFormatter::CURRENCY, true, 2],
+            [41, 'USD', '$0.41', \NumberFormatter::CURRENCY, true, 2],
+            [5, 'USD', '$0.05', \NumberFormatter::CURRENCY, true, 2],
+            [5, 'USD', '$0.050', \NumberFormatter::CURRENCY, true, 3],
+            [35, 'USD', '$0.350', \NumberFormatter::CURRENCY, true, 3],
+            [135, 'USD', '$1.350', \NumberFormatter::CURRENCY, true, 3],
+            [6135, 'USD', '$61.350', \NumberFormatter::CURRENCY, true, 3],
+            [-6135, 'USD', '-$61.350', \NumberFormatter::CURRENCY, true, 3],
+            [-6152, 'USD', '-$61.5', \NumberFormatter::CURRENCY, true, 1],
+            [5, 'EUR', '€0.05', \NumberFormatter::CURRENCY, true, 2],
+            [50, 'EUR', '€0.50', \NumberFormatter::CURRENCY, true, 2],
+            [500, 'EUR', '€5.00', \NumberFormatter::CURRENCY, true, 2],
+            [5, 'EUR', '€0.05', \NumberFormatter::DECIMAL, true, 2],
+            [50, 'EUR', '€0.50', \NumberFormatter::DECIMAL, true, 2],
+            [500, 'EUR', '€5.00', \NumberFormatter::DECIMAL, true, 2],
+            [5, 'EUR', '0', \NumberFormatter::DECIMAL, false, 0],
+            [50, 'EUR', '0', \NumberFormatter::DECIMAL, false, 0],
+            [500, 'EUR', '5', \NumberFormatter::DECIMAL, false, 0],
+            [5, 'EUR', '5%', \NumberFormatter::PERCENT, false, 0],
+            [5055, 'USD', '$51', \NumberFormatter::CURRENCY, true, 0],
         ];
     }
 }

--- a/tests/Parser/IntlMoneyParserTest.php
+++ b/tests/Parser/IntlMoneyParserTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Money\Parser;
 
+use Money\Currencies\ISOCurrencies;
 use Money\Parser\IntlMoneyParser;
 
 final class IntlMoneyParserTest extends \PHPUnit_Framework_TestCase
@@ -14,7 +15,7 @@ final class IntlMoneyParserTest extends \PHPUnit_Framework_TestCase
         $formatter = new \NumberFormatter('en_US', \NumberFormatter::CURRENCY);
         $formatter->setPattern('¤#,##0.00;-¤#,##0.00');
 
-        $parser = new IntlMoneyParser($formatter);
+        $parser = new IntlMoneyParser($formatter, new ISOCurrencies());
         $this->assertEquals($units, $parser->parse($string, 'USD')->getAmount());
     }
 
@@ -50,7 +51,7 @@ final class IntlMoneyParserTest extends \PHPUnit_Framework_TestCase
         $formatter = new \NumberFormatter('en_US', \NumberFormatter::CURRENCY);
         $formatter->setPattern('¤#,##0.00;-¤#,##0.00');
 
-        $parser = new IntlMoneyParser($formatter);
+        $parser = new IntlMoneyParser($formatter, new ISOCurrencies());
         $parser->parse('THIS_IS_NOT_CONVERTABLE_TO_UNIT', 'USD');
     }
 
@@ -59,7 +60,7 @@ final class IntlMoneyParserTest extends \PHPUnit_Framework_TestCase
         $formatter = new \NumberFormatter('en_CA', \NumberFormatter::CURRENCY);
         $formatter->setPattern('¤#,##0.00;-¤#,##0.00');
 
-        $parser = new IntlMoneyParser($formatter);
+        $parser = new IntlMoneyParser($formatter, new ISOCurrencies());
         $money = $parser->parse('$1000.00');
 
         $this->assertEquals('100000', $money->getAmount());
@@ -71,7 +72,7 @@ final class IntlMoneyParserTest extends \PHPUnit_Framework_TestCase
         $formatter = new \NumberFormatter('en_US', \NumberFormatter::CURRENCY);
         $formatter->setPattern('¤#,##0.00;-¤#,##0.00');
 
-        $parser = new IntlMoneyParser($formatter);
+        $parser = new IntlMoneyParser($formatter, new ISOCurrencies());
         $money = $parser->parse('$1000.00', 'CAD');
 
         $this->assertEquals('100000', $money->getAmount());
@@ -84,10 +85,10 @@ final class IntlMoneyParserTest extends \PHPUnit_Framework_TestCase
         $formatter->setPattern('¤#,##0.00;-¤#,##0.00');
         $formatter->setAttribute(\NumberFormatter::FRACTION_DIGITS, 3);
 
-        $parser = new IntlMoneyParser($formatter);
+        $parser = new IntlMoneyParser($formatter, new ISOCurrencies());
         $money = $parser->parse('$1000.005');
 
-        $this->assertEquals('1000005', $money->getAmount());
+        $this->assertEquals('100001', $money->getAmount());
     }
 
     public function testDifferentStyleWithPattern()
@@ -96,9 +97,9 @@ final class IntlMoneyParserTest extends \PHPUnit_Framework_TestCase
         $formatter->setPattern('¤#,##0.00;-¤#,##0.00');
         $formatter->setAttribute(\NumberFormatter::FRACTION_DIGITS, 3);
 
-        $parser = new IntlMoneyParser($formatter);
+        $parser = new IntlMoneyParser($formatter, new ISOCurrencies());
         $money = $parser->parse('$1000.005');
 
-        $this->assertEquals('1000005', $money->getAmount());
+        $this->assertEquals('100001', $money->getAmount());
     }
 }


### PR DESCRIPTION
Format currencies with subunits by using a subunit provider. Built-in providers are Constant and ISO. A follow-up PR might refactor `ISOCurrencies` and `ISOProvider` to use a single `ISORepository` or `ISOFactory`.

Questions:
1. Is `Provider` the correct name in this context?
2. What do you feel about the architectural decisions?
3. What about namespaces? Is everything in the correct place?

Please give me feedback on those important issues. Afterwards we can discuss secondary style issues. /cc @sagikazarmark 

Fixes: #221 #232 #233 #223.