### PR TITLE
Extend currency with subunit and name

### DIFF
--- a/spec/Currencies/AggregateCurrenciesSpec.php
+++ b/spec/Currencies/AggregateCurrenciesSpec.php
@@ -4,6 +4,7 @@ namespace spec\Money\Currencies;
 
 use Money\Currencies;
 use Money\Currency;
+use Money\Exception\UnknownCurrencyException;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
@@ -35,12 +36,20 @@ class AggregateCurrenciesSpec extends ObjectBehavior
         $this->contains(new Currency('EUR'))->shouldReturn(true);
     }
 
-    function testItDoesNotContainCurrencies()
+    function testItDoesNotContainCurrencies(Currencies $isoCurrencies, Currencies $otherCurrencies)
     {
         $isoCurrencies->contains(Argument::type(Currency::class))->willReturn(false);
         $otherCurrencies->contains(Argument::type(Currency::class))->willReturn(true);
 
         $this->contains(new Currency('EUR'))->shouldReturn(false);
+    }
+
+    function it_throws_an_exception_when_currency_is_unknown(Currencies $isoCurrencies, Currencies $otherCurrencies)
+    {
+        $isoCurrencies->find('XXXX')->willThrow(UnknownCurrencyException::class);
+        $otherCurrencies->find('XXXX')->willThrow(UnknownCurrencyException::class);
+
+        $this->shouldThrow(UnknownCurrencyException::class)->duringFind('XXXX');
     }
 
     function testConstructorThrowsAnException()

--- a/spec/Currencies/BitcoinCurrenciesSpec.php
+++ b/spec/Currencies/BitcoinCurrenciesSpec.php
@@ -4,6 +4,7 @@ namespace spec\Money\Currencies;
 
 use Money\Currencies;
 use Money\Currency;
+use Money\Exception\UnknownCurrencyException;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
@@ -23,5 +24,15 @@ class BitcoinCurrenciesSpec extends ObjectBehavior
     {
         $this->contains(new Currency('XBT'))->shouldReturn(true);
         $this->contains(new Currency('EUR'))->shouldReturn(false);
+    }
+
+    function it_can_find_bitcoin()
+    {
+        $this->find('XBT')->shouldReturnAnInstanceOf('Money\\Currency');
+    }
+
+    function it_throws_an_exception_when_currency_is_unknown()
+    {
+        $this->shouldThrow(UnknownCurrencyException::class)->duringFind('XXXX');
     }
 }

--- a/spec/Currencies/CachedCurrenciesSpec.php
+++ b/spec/Currencies/CachedCurrenciesSpec.php
@@ -59,4 +59,21 @@ class CachedCurrenciesSpec extends ObjectBehavior
 
         $this->contains(new Currency('EUR'))->shouldReturn(true);
     }
+
+    function it_finds_currencies_from_the_cache(
+        CacheItemInterface $item,
+        CacheItemPoolInterface $pool,
+        Currencies $currencies
+    ) {
+        $item->isHit()->willReturn(true);
+        $item->set(Argument::type(Currency::class))->shouldNotBeCalled();
+        $item->get()->willReturn(new Currency('EUR'));
+
+        $pool->getItem('currency|code|EUR')->willReturn($item);
+        $pool->save($item)->shouldNotBeCalled();
+
+        $currencies->find(Argument::type(Currency::class))->shouldNotBeCalled();
+
+        $this->find('EUR')->shouldReturnAnInstanceOf('Money\\Currency');
+    }
 }

--- a/spec/Currencies/ISOCurrenciesSpec.php
+++ b/spec/Currencies/ISOCurrenciesSpec.php
@@ -32,11 +32,6 @@ class ISOCurrenciesSpec extends ObjectBehavior
         $this->shouldThrow(UnknownCurrencyException::class)->duringFind('XXXX');
     }
 
-    function it_provides_a_list_of_currencies()
-    {
-        $this->getIterator()->shouldReturnAnInstanceOf('ArrayIterator');
-    }
-
     public function currencyCodeExamples()
     {
         $currencies = require __DIR__.'/../../vendor/moneyphp/iso-currencies/resources/current.php';

--- a/spec/Currencies/ISOCurrenciesSpec.php
+++ b/spec/Currencies/ISOCurrenciesSpec.php
@@ -32,6 +32,11 @@ class ISOCurrenciesSpec extends ObjectBehavior
         $this->shouldThrow(UnknownCurrencyException::class)->duringFind('XXXX');
     }
 
+    function it_provides_a_list_of_currencies()
+    {
+        $this->getIterator()->shouldReturnAnInstanceOf('ArrayIterator');
+    }
+
     public function currencyCodeExamples()
     {
         $currencies = require __DIR__.'/../../vendor/moneyphp/iso-currencies/resources/current.php';

--- a/spec/Currencies/ISOCurrenciesSpec.php
+++ b/spec/Currencies/ISOCurrenciesSpec.php
@@ -4,6 +4,7 @@ namespace spec\Money\Currencies;
 
 use Money\Currencies;
 use Money\Currency;
+use Money\Exception\UnknownCurrencyException;
 use PhpSpec\ObjectBehavior;
 
 class ISOCurrenciesSpec extends ObjectBehavior
@@ -24,6 +25,11 @@ class ISOCurrenciesSpec extends ObjectBehavior
     function it_contains_iso_currencies($currency)
     {
         $this->contains(new Currency($currency))->shouldReturn(true);
+    }
+
+    function it_throws_an_exception_when_currency_is_unknown()
+    {
+        $this->shouldThrow(UnknownCurrencyException::class)->duringFind('XXXX');
     }
 
     public function currencyCodeExamples()

--- a/spec/CurrencySpec.php
+++ b/spec/CurrencySpec.php
@@ -29,11 +29,6 @@ class CurrencySpec extends ObjectBehavior
         $this->shouldThrow(\InvalidArgumentException::class)->duringWithSubunit('test');
     }
 
-    function it_throws_an_exception_when_name_is_not_string()
-    {
-        $this->shouldThrow(\InvalidArgumentException::class)->duringWithName(1);
-    }
-
     function it_has_a_code()
     {
         $this->getCode()->shouldReturn('EUR');

--- a/spec/CurrencySpec.php
+++ b/spec/CurrencySpec.php
@@ -24,6 +24,16 @@ class CurrencySpec extends ObjectBehavior
         $this->shouldThrow(\InvalidArgumentException::class)->duringInstantiation();
     }
 
+    function it_throws_an_exception_when_subunit_is_not_integer()
+    {
+        $this->shouldThrow(\InvalidArgumentException::class)->duringWithSubunit('test');
+    }
+
+    function it_throws_an_exception_when_name_is_not_string()
+    {
+        $this->shouldThrow(\InvalidArgumentException::class)->duringWithName(1);
+    }
+
     function it_has_a_code()
     {
         $this->getCode()->shouldReturn('EUR');

--- a/spec/Formatter/IntlMoneyFormatterSpec.php
+++ b/spec/Formatter/IntlMoneyFormatterSpec.php
@@ -2,6 +2,8 @@
 
 namespace spec\Money\Formatter;
 
+use Money\Currencies\Specification;
+use Money\CurrenciesSpecification;
 use Money\Currency;
 use Money\Money;
 use Money\MoneyFormatter;
@@ -26,10 +28,9 @@ class IntlMoneyFormatterSpec extends ObjectBehavior
 
     function it_formats_money(\NumberFormatter $numberFormatter)
     {
-        $numberFormatter->getAttribute(\NumberFormatter::FRACTION_DIGITS)->willReturn(2);
-        $numberFormatter->formatCurrency('0.01', 'EUR')->willReturn('€1.00');
+        $money = new Money(1, (new Currency('EUR'))->withSubunit(2));
 
-        $money = new Money(1, new Currency('EUR'));
+        $numberFormatter->formatCurrency('0.01', 'EUR')->willReturn('€1.00');
 
         $this->format($money)->shouldReturn('€1.00');
     }

--- a/src/Currencies.php
+++ b/src/Currencies.php
@@ -2,6 +2,8 @@
 
 namespace Money;
 
+use Money\Exception\UnknownCurrencyException;
+
 /**
  * Implement this to provide a list of currencies.
  *
@@ -17,4 +19,13 @@ interface Currencies
      * @return bool
      */
     public function contains(Currency $currency);
+
+    /**
+     * @param string $code
+     *
+     * @return Currency
+     *
+     * @throws UnknownCurrencyException
+     */
+    public function find($code);
 }

--- a/src/Currencies/AggregateCurrencies.php
+++ b/src/Currencies/AggregateCurrencies.php
@@ -4,6 +4,7 @@ namespace Money\Currencies;
 
 use Money\Currencies;
 use Money\Currency;
+use Money\Exception\UnknownCurrencyException;
 
 /**
  * Aggregates several currency repositories.
@@ -43,5 +44,20 @@ final class AggregateCurrencies implements Currencies
         }
 
         return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function find($code)
+    {
+        foreach ($this->currencies as $c) {
+            try {
+                return $c->find($code);
+            } catch (UnknownCurrencyException $e) {
+            }
+        }
+
+        throw new UnknownCurrencyException('Cannot find currency code '.$code);
     }
 }

--- a/src/Currencies/BitcoinCurrencies.php
+++ b/src/Currencies/BitcoinCurrencies.php
@@ -33,11 +33,14 @@ final class BitcoinCurrencies implements Currencies
      */
     public function find($code)
     {
+        if ($code !== self::CODE) {
+            throw new UnknownCurrencyException('Cannot find Bitcoin currency '.$code);
+        }
+
         if (null === self::$currency) {
             self::$currency = (new Currency(self::CODE))
                 ->withName('Bitcoin')
-                ->withSubunit(0)
-                ->withEntity('Bitcoin');
+                ->withSubunit(8);
         }
 
         return self::$currency;

--- a/src/Currencies/BitcoinCurrencies.php
+++ b/src/Currencies/BitcoinCurrencies.php
@@ -4,6 +4,7 @@ namespace Money\Currencies;
 
 use Money\Currencies;
 use Money\Currency;
+use Money\Exception\UnknownCurrencyException;
 
 /**
  * @author Frederik Bosch <f.bosch@genkgo.nl>
@@ -13,11 +14,32 @@ final class BitcoinCurrencies implements Currencies
     const CODE = 'XBT';
     const SYMBOL = "\0xC9\0x83";
 
+    private static $currency;
+
     /**
      * {@inheritdoc}
      */
     public function contains(Currency $currency)
     {
         return self::CODE === $currency->getCode();
+    }
+
+    /**
+     * @param string $code
+     *
+     * @return Currency
+     *
+     * @throws UnknownCurrencyException
+     */
+    public function find($code)
+    {
+        if (null === self::$currency) {
+            self::$currency = (new Currency(self::CODE))
+                ->withName('Bitcoin')
+                ->withSubunit(0)
+                ->withEntity('Bitcoin');
+        }
+
+        return self::$currency;
     }
 }

--- a/src/Currencies/BitcoinCurrencies.php
+++ b/src/Currencies/BitcoinCurrencies.php
@@ -39,7 +39,6 @@ final class BitcoinCurrencies implements Currencies
 
         if (null === self::$currency) {
             self::$currency = (new Currency(self::CODE))
-                ->withName('Bitcoin')
                 ->withSubunit(8);
         }
 

--- a/src/Currencies/CachedCurrencies.php
+++ b/src/Currencies/CachedCurrencies.php
@@ -53,4 +53,24 @@ final class CachedCurrencies implements Currencies
 
         return $item->get();
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function find($code)
+    {
+        $item = $this->pool->getItem('currency|code|'.$code);
+
+        if (false === $item->isHit()) {
+            $item->set($this->currencies->find($code));
+
+            if ($item instanceof TaggableItemInterface) {
+                $item->addTag('currency.code');
+            }
+
+            $this->pool->save($item);
+        }
+
+        return $item->get();
+    }
 }

--- a/src/Currencies/ISOCurrencies.php
+++ b/src/Currencies/ISOCurrencies.php
@@ -60,28 +60,13 @@ final class ISOCurrencies implements Currencies, IteratorAggregate
 
         self::$currencies[$code] = (new Currency($code))
             ->withSubunit(self::$currencyData[$code]['minorUnit'])
-            ->withName(self::$currencyData[$code]['currency'])
-            ->withEntity(self::$currencyData[$code]['entity']);
+            ->withName(self::$currencyData[$code]['currency']);
 
         return self::$currencies[$code];
     }
 
     /**
-     * @return array
-     */
-    private function loadCurrencies()
-    {
-        $file = __DIR__.'/../../vendor/moneyphp/iso-currencies/resources/current.php';
-
-        if (file_exists($file)) {
-            return require $file;
-        }
-
-        throw new \RuntimeException('Failed to load currency ISO codes.');
-    }
-
-    /**
-     * @return Traversable
+     * @return Traversable|Currency[]
      */
     public function getIterator()
     {
@@ -96,13 +81,26 @@ final class ISOCurrencies implements Currencies, IteratorAggregate
             if (!isset(self::$currencies[$code])) {
                 self::$currencies[$code] = (new Currency($code))
                     ->withSubunit(self::$currencyData[$code]['minorUnit'])
-                    ->withName(self::$currencyData[$code]['currency'])
-                    ->withEntity(self::$currencyData[$code]['entity']);
+                    ->withName(self::$currencyData[$code]['currency']);
             }
 
             $list[] = self::$currencies[$code];
         }
 
         return new ArrayIterator($list);
+    }
+
+    /**
+     * @return array
+     */
+    private function loadCurrencies()
+    {
+        $file = __DIR__.'/../../vendor/moneyphp/iso-currencies/resources/current.php';
+
+        if (file_exists($file)) {
+            return require $file;
+        }
+
+        throw new \RuntimeException('Failed to load currency ISO codes.');
     }
 }

--- a/src/Currencies/ISOCurrencies.php
+++ b/src/Currencies/ISOCurrencies.php
@@ -2,16 +2,26 @@
 
 namespace Money\Currencies;
 
+use ArrayIterator;
+use IteratorAggregate;
 use Money\Currencies;
 use Money\Currency;
+use Money\Exception\UnknownCurrencyException;
+use Traversable;
 
 /**
  * List of supported ISO 4217 currency codes and names.
  *
  * @author Mathias Verraes
  */
-final class ISOCurrencies implements Currencies
+final class ISOCurrencies implements Currencies, IteratorAggregate
 {
+    /**
+     * Currency data from data source.
+     *
+     * @var array
+     */
+    private static $currencyData;
     /**
      * List of known currencies.
      *
@@ -24,13 +34,41 @@ final class ISOCurrencies implements Currencies
      */
     public function contains(Currency $currency)
     {
-        if (null === self::$currencies) {
-            self::$currencies = $this->loadCurrencies();
+        if (null === self::$currencyData) {
+            self::$currencyData = $this->loadCurrencies();
         }
 
-        return isset(self::$currencies[$currency->getCode()]);
+        return isset(self::$currencyData[$currency->getCode()]);
     }
 
+    /**
+     * {@inheritdoc}
+     */
+    public function find($code)
+    {
+        if (isset(self::$currencies[$code])) {
+            return self::$currencies[$code];
+        }
+
+        if (null === self::$currencyData) {
+            self::$currencyData = $this->loadCurrencies();
+        }
+
+        if (!isset(self::$currencyData[$code])) {
+            throw new UnknownCurrencyException('Cannot find ISO currency '.$code);
+        }
+
+        self::$currencies[$code] = (new Currency($code))
+            ->withSubunit(self::$currencyData[$code]['minorUnit'])
+            ->withName(self::$currencyData[$code]['currency'])
+            ->withEntity(self::$currencyData[$code]['entity']);
+
+        return self::$currencies[$code];
+    }
+
+    /**
+     * @return array
+     */
     private function loadCurrencies()
     {
         $file = __DIR__.'/../../vendor/moneyphp/iso-currencies/resources/current.php';
@@ -40,5 +78,31 @@ final class ISOCurrencies implements Currencies
         }
 
         throw new \RuntimeException('Failed to load currency ISO codes.');
+    }
+
+    /**
+     * @return Traversable
+     */
+    public function getIterator()
+    {
+        $list = [];
+
+        if (null === self::$currencyData) {
+            self::$currencyData = $this->loadCurrencies();
+        }
+
+        $codes = array_keys(self::$currencyData);
+        foreach ($codes as $code) {
+            if (!isset(self::$currencies[$code])) {
+                self::$currencies[$code] = (new Currency($code))
+                    ->withSubunit(self::$currencyData[$code]['minorUnit'])
+                    ->withName(self::$currencyData[$code]['currency'])
+                    ->withEntity(self::$currencyData[$code]['entity']);
+            }
+
+            $list[] = self::$currencies[$code];
+        }
+
+        return new ArrayIterator($list);
     }
 }

--- a/src/Currencies/ISOCurrencies.php
+++ b/src/Currencies/ISOCurrencies.php
@@ -2,19 +2,16 @@
 
 namespace Money\Currencies;
 
-use ArrayIterator;
-use IteratorAggregate;
 use Money\Currencies;
 use Money\Currency;
 use Money\Exception\UnknownCurrencyException;
-use Traversable;
 
 /**
  * List of supported ISO 4217 currency codes and names.
  *
  * @author Mathias Verraes
  */
-final class ISOCurrencies implements Currencies, IteratorAggregate
+final class ISOCurrencies implements Currencies
 {
     /**
      * Currency data from data source.
@@ -59,35 +56,9 @@ final class ISOCurrencies implements Currencies, IteratorAggregate
         }
 
         self::$currencies[$code] = (new Currency($code))
-            ->withSubunit(self::$currencyData[$code]['minorUnit'])
-            ->withName(self::$currencyData[$code]['currency']);
+            ->withSubunit(self::$currencyData[$code]['minorUnit']);
 
         return self::$currencies[$code];
-    }
-
-    /**
-     * @return Traversable|Currency[]
-     */
-    public function getIterator()
-    {
-        $list = [];
-
-        if (null === self::$currencyData) {
-            self::$currencyData = $this->loadCurrencies();
-        }
-
-        $codes = array_keys(self::$currencyData);
-        foreach ($codes as $code) {
-            if (!isset(self::$currencies[$code])) {
-                self::$currencies[$code] = (new Currency($code))
-                    ->withSubunit(self::$currencyData[$code]['minorUnit'])
-                    ->withName(self::$currencyData[$code]['currency']);
-            }
-
-            $list[] = self::$currencies[$code];
-        }
-
-        return new ArrayIterator($list);
     }
 
     /**

--- a/src/Currency.php
+++ b/src/Currency.php
@@ -21,10 +21,6 @@ final class Currency implements \JsonSerializable
      * @var int
      */
     private $subunit = 0;
-    /**
-     * @var string
-     */
-    private $name = '';
 
     /**
      * @param string $code
@@ -56,23 +52,6 @@ final class Currency implements \JsonSerializable
     }
 
     /**
-     * @param string $name
-     *
-     * @return Currency
-     */
-    public function withName($name)
-    {
-        if (!is_string($name)) {
-            throw new \InvalidArgumentException('Name should be a string');
-        }
-
-        $clone = clone $this;
-        $clone->name = $name;
-
-        return $clone;
-    }
-
-    /**
      * Returns the currency code.
      *
      * @return string
@@ -80,14 +59,6 @@ final class Currency implements \JsonSerializable
     public function getCode()
     {
         return $this->code;
-    }
-
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return $this->name;
     }
 
     /**

--- a/src/Currency.php
+++ b/src/Currency.php
@@ -25,10 +25,6 @@ final class Currency implements \JsonSerializable
      * @var string
      */
     private $name = '';
-    /**
-     * @var string
-     */
-    private $entity = '';
 
     /**
      * @param string $code
@@ -66,21 +62,12 @@ final class Currency implements \JsonSerializable
      */
     public function withName($name)
     {
+        if (!is_string($name)) {
+            throw new \InvalidArgumentException('Name should be a string');
+        }
+
         $clone = clone $this;
         $clone->name = $name;
-
-        return $clone;
-    }
-
-    /**
-     * @param string $entity
-     *
-     * @return Currency
-     */
-    public function withEntity($entity)
-    {
-        $clone = clone $this;
-        $clone->entity = $entity;
 
         return $clone;
     }
@@ -93,14 +80,6 @@ final class Currency implements \JsonSerializable
     public function getCode()
     {
         return $this->code;
-    }
-
-    /**
-     * @return string
-     */
-    public function getEntity()
-    {
-        return $this->entity;
     }
 
     /**

--- a/src/Currency.php
+++ b/src/Currency.php
@@ -17,6 +17,18 @@ final class Currency implements \JsonSerializable
      * @var string
      */
     private $code;
+    /**
+     * @var int
+     */
+    private $subunit = 0;
+    /**
+     * @var string
+     */
+    private $name = '';
+    /**
+     * @var string
+     */
+    private $entity = '';
 
     /**
      * @param string $code
@@ -31,6 +43,49 @@ final class Currency implements \JsonSerializable
     }
 
     /**
+     * @param int $subunit
+     *
+     * @return Currency
+     */
+    public function withSubunit($subunit)
+    {
+        if (!is_int($subunit)) {
+            throw new \InvalidArgumentException('Subunit should be an integer');
+        }
+
+        $clone = clone $this;
+        $clone->subunit = $subunit;
+
+        return $clone;
+    }
+
+    /**
+     * @param string $name
+     *
+     * @return Currency
+     */
+    public function withName($name)
+    {
+        $clone = clone $this;
+        $clone->name = $name;
+
+        return $clone;
+    }
+
+    /**
+     * @param string $entity
+     *
+     * @return Currency
+     */
+    public function withEntity($entity)
+    {
+        $clone = clone $this;
+        $clone->entity = $entity;
+
+        return $clone;
+    }
+
+    /**
      * Returns the currency code.
      *
      * @return string
@@ -38,6 +93,30 @@ final class Currency implements \JsonSerializable
     public function getCode()
     {
         return $this->code;
+    }
+
+    /**
+     * @return string
+     */
+    public function getEntity()
+    {
+        return $this->entity;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @return int
+     */
+    public function getSubunit()
+    {
+        return $this->subunit;
     }
 
     /**

--- a/src/Exception/UnknownCurrencyException.php
+++ b/src/Exception/UnknownCurrencyException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Money\Exception;
+
+/**
+ * Thrown when trying to get ISO currency that does not exists.
+ *
+ * @author Frederik Bosch <f.bosch@genkgo.nl>
+ */
+final class UnknownCurrencyException extends \RuntimeException implements Exception
+{
+}

--- a/src/Formatter/IntlMoneyFormatter.php
+++ b/src/Formatter/IntlMoneyFormatter.php
@@ -2,6 +2,7 @@
 
 namespace Money\Formatter;
 
+use Money\Currencies;
 use Money\Money;
 use Money\MoneyFormatter;
 
@@ -33,25 +34,25 @@ final class IntlMoneyFormatter implements MoneyFormatter
         $valueBase = (string) $money->getAmount();
         $negative = false;
 
-        if (substr($valueBase, 0, 1) === '-') {
+        if ($valueBase[0] === '-') {
             $negative = true;
             $valueBase = substr($valueBase, 1);
         }
 
-        $fractionDigits = $this->formatter->getAttribute(\NumberFormatter::FRACTION_DIGITS);
+        $subunit = $money->getCurrency()->getSubunit();
         $valueLength = strlen($valueBase);
 
-        if ($valueLength > $fractionDigits) {
-            $subunits = substr($valueBase, 0, $valueLength - $fractionDigits).'.';
-            $subunits .= substr($valueBase, $valueLength - $fractionDigits);
+        if ($valueLength > $subunit) {
+            $formatted = substr($valueBase, 0, $valueLength - $subunit).'.';
+            $formatted .= substr($valueBase, $valueLength - $subunit);
         } else {
-            $subunits = '0.'.str_pad('', $fractionDigits - $valueLength, '0').$valueBase;
+            $formatted = '0.'.str_pad('', $subunit - $valueLength, '0').$valueBase;
         }
 
         if ($negative === true) {
-            $subunits = '-'.$subunits;
+            $formatted = '-'.$formatted;
         }
 
-        return $this->formatter->formatCurrency($subunits, $money->getCurrency()->getCode());
+        return $this->formatter->formatCurrency($formatted, $money->getCurrency()->getCode());
     }
 }

--- a/src/Formatter/IntlMoneyFormatter.php
+++ b/src/Formatter/IntlMoneyFormatter.php
@@ -2,7 +2,6 @@
 
 namespace Money\Formatter;
 
-use Money\Currencies;
 use Money\Money;
 use Money\MoneyFormatter;
 

--- a/tests/Currencies/ISOCurrenciesTest.php
+++ b/tests/Currencies/ISOCurrenciesTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Tests\Money\Currencies;
+
+use Money\Currencies\ISOCurrencies;
+
+final class ISOCurrenciesTest extends \PHPUnit_Framework_TestCase
+{
+    public function testIterator()
+    {
+        $currencies = new ISOCurrencies();
+        foreach ($currencies as $currency) {
+            $this->assertTrue(is_string($currency->getCode()));
+            $this->assertTrue(is_int($currency->getSubunit()));
+            $this->assertTrue(is_string($currency->getName()));
+        }
+    }
+
+    public function testFind()
+    {
+        $currencies = new ISOCurrencies();
+        $euro = $currencies->find('EUR');
+        $this->assertSame($euro, $currencies->find('EUR'));
+    }
+}

--- a/tests/Formatter/IntlMoneyFormatterTest.php
+++ b/tests/Formatter/IntlMoneyFormatterTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Money\Formatter;
 
-use Money\Currencies\ConstantSpecification;
 use Money\Currency;
 use Money\Formatter\IntlMoneyFormatter;
 use Money\Money;

--- a/tests/Formatter/IntlMoneyFormatterTest.php
+++ b/tests/Formatter/IntlMoneyFormatterTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Money\Formatter;
 
+use Money\Currencies\ConstantSpecification;
 use Money\Currency;
 use Money\Formatter\IntlMoneyFormatter;
 use Money\Money;
@@ -11,11 +12,11 @@ final class IntlMoneyFormatterTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider numberFormatterExamples
      */
-    public function testNumberFormatter($amount, $currency, $result, $locale, $mode, $hasPattern, $fractionDigits)
+    public function testNumberFormatter($amount, $currency, $result, $mode, $hasPattern, $subunit, $fractionDigits)
     {
-        $money = new Money($amount, new Currency($currency));
+        $money = new Money($amount, (new Currency($currency))->withSubunit($subunit));
 
-        $numberFormatter = new \NumberFormatter($locale, $mode);
+        $numberFormatter = new \NumberFormatter('en_US', $mode);
 
         if (true === $hasPattern) {
             $numberFormatter->setPattern('¤#,##0.00;-¤#,##0.00');
@@ -30,24 +31,26 @@ final class IntlMoneyFormatterTest extends \PHPUnit_Framework_TestCase
     public static function numberFormatterExamples()
     {
         return [
-            [100, 'USD', '$1.00', 'en_US', \NumberFormatter::CURRENCY, true, 2],
-            [41, 'USD', '$0.41', 'en_US', \NumberFormatter::CURRENCY, true, 2],
-            [5, 'USD', '$0.05', 'en_US', \NumberFormatter::CURRENCY, true, 2],
-            [5, 'USD', '$0.005', 'en_US', \NumberFormatter::CURRENCY, true, 3],
-            [35, 'USD', '$0.035', 'en_US', \NumberFormatter::CURRENCY, true, 3],
-            [135, 'USD', '$0.135', 'en_US', \NumberFormatter::CURRENCY, true, 3],
-            [6135, 'USD', '$6.135', 'en_US', \NumberFormatter::CURRENCY, true, 3],
-            [-6135, 'USD', '-$6.135', 'en_US', \NumberFormatter::CURRENCY, true, 3],
-            [5, 'EUR', '€0.05', 'en_US', \NumberFormatter::CURRENCY, true, 2],
-            [50, 'EUR', '€0.50', 'en_US', \NumberFormatter::CURRENCY, true, 2],
-            [500, 'EUR', '€5.00', 'en_US', \NumberFormatter::CURRENCY, true, 2],
-            [5, 'EUR', '€0.05', 'en_US', \NumberFormatter::DECIMAL, true, 2],
-            [50, 'EUR', '€0.50', 'en_US', \NumberFormatter::DECIMAL, true, 2],
-            [500, 'EUR', '€5.00', 'en_US', \NumberFormatter::DECIMAL, true, 2],
-            [5, 'EUR', '5', 'en_US', \NumberFormatter::DECIMAL, false, 0],
-            [50, 'EUR', '50', 'en_US', \NumberFormatter::DECIMAL, false, 0],
-            [500, 'EUR', '500', 'en_US', \NumberFormatter::DECIMAL, false, 0],
-            [5, 'EUR', '500%', 'en_US', \NumberFormatter::PERCENT, false, 0],
+            [5005, 'USD', '$50', \NumberFormatter::CURRENCY, true, 2, 0],
+            [100, 'USD', '$1.00', \NumberFormatter::CURRENCY, true, 2, 2],
+            [41, 'USD', '$0.41', \NumberFormatter::CURRENCY, true, 2, 2],
+            [5, 'USD', '$0.05', \NumberFormatter::CURRENCY, true, 2, 2],
+            [5, 'USD', '$0.005', \NumberFormatter::CURRENCY, true, 3, 3],
+            [35, 'USD', '$0.035', \NumberFormatter::CURRENCY, true, 3, 3],
+            [135, 'USD', '$0.135', \NumberFormatter::CURRENCY, true, 3, 3],
+            [6135, 'USD', '$6.135', \NumberFormatter::CURRENCY, true, 3, 3],
+            [-6135, 'USD', '-$6.135', \NumberFormatter::CURRENCY, true, 3, 3],
+            [-6152, 'USD', '-$6.2', \NumberFormatter::CURRENCY, true, 3, 1],
+            [5, 'EUR', '€0.05', \NumberFormatter::CURRENCY, true, 2, 2],
+            [50, 'EUR', '€0.50', \NumberFormatter::CURRENCY, true, 2, 2],
+            [500, 'EUR', '€5.00', \NumberFormatter::CURRENCY, true, 2, 2],
+            [5, 'EUR', '€0.05', \NumberFormatter::DECIMAL, true, 2, 2],
+            [50, 'EUR', '€0.50', \NumberFormatter::DECIMAL, true, 2, 2],
+            [500, 'EUR', '€5.00', \NumberFormatter::DECIMAL, true, 2, 2],
+            [5, 'EUR', '5', \NumberFormatter::DECIMAL, false, 0, 0],
+            [50, 'EUR', '50', \NumberFormatter::DECIMAL, false, 0, 0],
+            [500, 'EUR', '500', \NumberFormatter::DECIMAL, false, 0, 0],
+            [5, 'EUR', '500%', \NumberFormatter::PERCENT, false, 0, 0],
         ];
     }
 }


### PR DESCRIPTION
Instead of creating new objects like `CurrenciesSpecification` or `CurrenciesWithSubunit`, this solution adds functionality to `Currencies` and `Currency`. First of all: why this PR? I am not necessarily happy with PR #248. I still feel we are not there yet. Therefore I am trying different solutions. This should not be seen as how it must be, rather another shot at the problem. Maybe it contains something to continue on. Maybe it is crap.

But, here is why I think that this PR does contain some valid points.

1. Our `Currency` is coming short in our domain. A subunit is a property of the currency and should be modelled as such. There should not be another object for it. So no `CurrencySpecification`.

2. `Currencies` should - according to its description - 'provide a list of currencies'. But it is not. It only tells whether a currency is available within the context of the object. It is not *providing* a list. That is a problem. In my current applications every time I construct a `Money` object, I also construct a new `Currency`. Why? There is only one Euro or one US dollar currency. Hence my application should have one currency object per currency, not multiple. This implies that Currencies - because its responsibility is to *provide* currencies - should actually start doing that. This is what is achieved with the `find` method on the object. It returns a currency object and always the same object per currency code.

3. But now `Currencies` has more than one method on its interface: that is multiple responsibility! I disagree here. Single responsibility does not imply that an interface should have one method. Of course, functional interface (those with one method) should be preferred over those with many methods. But in this case, the domain requires there to be more than one method. I compare it with [container-interop](https://github.com/container-interop/container-interop/blob/master/src/Interop/Container/ContainerInterface.php#L14). That is not a bad interface, is it? `contains` <-> `has` and `find` <-> `get`.

Maybe you can shoot at the points I am making. Because I think we need some more iterations before we will find the solution we are looking for.

/cc @sagikazarmark @pamil @Sharom 