### PR TITLE
Fix integer detection when the number overflows the integer type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+
+## Unreleased
+
+### Fixed
+
+- Integer detection when the number overflows the integer type and contains zeros
+
+
 ## 3.0.0-beta.2 - 2016-08-03
 
 ### Changed

--- a/spec/NumberSpec.php
+++ b/spec/NumberSpec.php
@@ -53,6 +53,14 @@ class NumberSpec extends ObjectBehavior
         $this->getIntegerRoundingMultiplier()->shouldReturn($negative ? '-1' : '1');
     }
 
+    /**
+     * @dataProvider numberExamples
+     */
+    function it_tests_if_the_number_is_integer($number, $decimal)
+    {
+        $this->isInteger($number)->shouldReturn(!$decimal);
+    }
+
     public function numberExamples()
     {
         return [
@@ -77,6 +85,33 @@ class NumberSpec extends ObjectBehavior
             ['-10.5', true, true, true, true, '-10', '5'],
             [(string) PHP_INT_MAX, false, false, false, false, (string) PHP_INT_MAX, ''],
             [(string) -PHP_INT_MAX, false, false, false, true, (string) -PHP_INT_MAX, ''],
+            [
+                PHP_INT_MAX.PHP_INT_MAX.PHP_INT_MAX,
+                false,
+                false,
+                false,
+                false,
+                PHP_INT_MAX.PHP_INT_MAX.PHP_INT_MAX,
+                ''
+            ],
+            [
+                -PHP_INT_MAX.PHP_INT_MAX.PHP_INT_MAX,
+                false,
+                false,
+                false,
+                true,
+                -PHP_INT_MAX.PHP_INT_MAX.PHP_INT_MAX,
+                ''
+            ],
+            [
+                substr(PHP_INT_MAX, 0, strlen((string) PHP_INT_MAX) - 1).str_repeat('0', strlen((string) PHP_INT_MAX) - 1).PHP_INT_MAX,
+                false,
+                false,
+                false,
+                false,
+                substr(PHP_INT_MAX, 0, strlen((string) PHP_INT_MAX) - 1).str_repeat('0', strlen((string) PHP_INT_MAX) - 1).PHP_INT_MAX,
+                ''
+            ],
         ];
     }
 }

--- a/src/Number.php
+++ b/src/Number.php
@@ -165,14 +165,20 @@ final class Number
      */
     public static function isInteger($number)
     {
-        if (filter_var($number, FILTER_VALIDATE_INT) !== false) {
+        // Check if number is a valid integer
+        if (false !== filter_var($number, FILTER_VALIDATE_INT)) {
             return true;
         }
 
+        // Check if number is invalid because of integer overflow
         $invalid = array_filter(
             str_split($number, strlen((string) PHP_INT_MAX) - 1),
             function ($chunk) {
-                return filter_var($chunk, FILTER_VALIDATE_INT) === false;
+                // Leading zeros should not invalidate the chunk
+                $chunk = ltrim($chunk, '0');
+
+                // Allow chunks containing zeros only
+                return '' !== $chunk && false === filter_var($chunk, FILTER_VALIDATE_INT);
             }
         );
 


### PR DESCRIPTION
When the number overflows integer type it's split into chunks
and checked step by step. When the chunk starts with a zero
the type check fails since an integer cannot start with zero.

Closes #276