### PR TITLE
Fix converting currencies with different subunits

### DIFF
--- a/doc/CurrencyConversion.rst
+++ b/doc/CurrencyConversion.rst
@@ -1,7 +1,65 @@
 Currency Conversion
 ===================
 
-To convert a Money instance from one Currency to another, you need a CurrencyPair.
+To convert a Money instance from one Currency to another, you need the Converter. This class depends on
+:doc:`Currencies` and Exchange. Exchange returns a `CurrencyPair`, which is the combination of the base
+currency, counter currency and the conversion ratio.
+
+Fixed Exchange
+--------------
+
+You can use a fixed exchange to convert `Money` into another Currency.
+
+.. code:: php
+
+    use Money\Converter;
+    use Money\Currency;
+    use Money\Exchange\FixedExchange;
+
+    $exchange = new FixedExchange([
+        'EUR' => [
+            'USD' => 1.25
+        ]
+    ]);
+
+    $converter = new Converter(new ISOCurrencies(), $exchange);
+
+    $eur100 = Money::EUR(100);
+    $usd125 = $converter->convert($eur100, new Currency('USD'));
+
+Third Party Exchange
+--------------------
+
+We also provide a way to integrate external sources of conversion rates by implementing
+the ``Money\Exchange`` interface. There is a default one in the core using Swap_
+which you can install via Composer_:
+
+.. code:: bash
+
+    $ composer require florianv/swap
+
+
+Then conversion is quite simple:
+
+.. code:: php
+
+    use Money\Money;
+    use Money\Converter;
+
+    // $swap = Implementation of \Swap\SwapInterface
+    $exchange = new SwapExchange($swap);
+
+    $converter = new Converter(new ISOCurrencies(), $exchange);
+    $eur100 = Money::EUR(100);
+    $usd125 = $converter->convert($eur100, $pair);
+
+
+.. _Swap: https://github.com/florianv/swap
+.. _Composer: https://getcomposer.org
+
+
+CurrencyPair
+------------
 You can use the OOP notation to define a pair:
 
 .. code:: php
@@ -21,17 +79,8 @@ means that one euro is exchanged for 1.2500 US dollars.
 
     $pair = CurrencyPair::createFromIso('EUR/USD 1.2500');
 
-
-We also provide a way to integrate external sources of conversion rates by implementing
-the ``Money\Exchange`` interface. There is a default one in the core using Swap_
-which you can install via Composer_:
-
-.. code:: bash
-
-    $ composer require florianv/swap
-
-
-Then use it to create a pair:
+You could also create a pair using a third party. There is a default one in the core using Swap_
+which you can install via Composer_.
 
 .. code:: php
 
@@ -45,19 +94,3 @@ Then use it to create a pair:
     $exchange = new SwapExchange($swap);
 
     $pair = $exchange->quote($eur, $usd);
-
-
-After having the correct currency pair, conversion is quite simple:
-
-.. code:: php
-
-    use Money\Money;
-    use Money\Converter;
-
-    $converter = new Converter(new ISOCurrencies());
-    $eur100 = Money::EUR(100);
-    $usd125 = $converter->convert($eur100, $pair);
-
-
-.. _Swap: https://github.com/florianv/swap
-.. _Composer: https://getcomposer.org

--- a/doc/CurrencyConversion.rst
+++ b/doc/CurrencyConversion.rst
@@ -60,7 +60,9 @@ Then conversion is quite simple:
 
 CurrencyPair
 ------------
-You can use the OOP notation to define a pair:
+
+A CurrencyPair is returned by the Exchange. If you want to implement your own Exchange, you can use
+the OOP notation to define a pair:
 
 .. code:: php
 
@@ -70,7 +72,7 @@ You can use the OOP notation to define a pair:
     $pair = new CurrencyPair(new Currency('EUR'), new Currency('USD'), 1.2500);
 
 
-You can also parse ISO notations. For example, the quotation ``EUR/USD 1.2500``
+But you can also parse ISO notations. For example, the quotation ``EUR/USD 1.2500``
 means that one euro is exchanged for 1.2500 US dollars.
 
 .. code:: php

--- a/doc/CurrencyConversion.rst
+++ b/doc/CurrencyConversion.rst
@@ -44,7 +44,7 @@ Then use it to create a pair:
     // $swap = Implementation of \Swap\SwapInterface
     $exchange = new SwapExchange($swap);
 
-    $pair = $exchange->getCurrencyPair($eur, $usd);
+    $pair = $exchange->quote($eur, $usd);
 
 
 After having the correct currency pair, conversion is quite simple:
@@ -52,9 +52,11 @@ After having the correct currency pair, conversion is quite simple:
 .. code:: php
 
     use Money\Money;
+    use Money\Converter;
 
+    $converter = new Converter(new ISOCurrencies());
     $eur100 = Money::EUR(100);
-    $usd125 = $pair->convert($eur100);
+    $usd125 = $converter->convert($eur100, $pair);
 
 
 .. _Swap: https://github.com/florianv/swap

--- a/doc/CurrencyConversion.rst
+++ b/doc/CurrencyConversion.rst
@@ -2,7 +2,7 @@ Currency Conversion
 ===================
 
 To convert a Money instance from one Currency to another, you need the Converter. This class depends on
-:doc:`Currencies` and Exchange. Exchange returns a `CurrencyPair`, which is the combination of the base
+Currencies and Exchange. Exchange returns a `CurrencyPair`, which is the combination of the base
 currency, counter currency and the conversion ratio.
 
 Fixed Exchange

--- a/spec/ConverterSpec.php
+++ b/spec/ConverterSpec.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace spec\Money;
+
+use Money\Calculator;
+use Money\Currencies;
+use Money\Currency;
+use Money\CurrencyPair;
+use Money\Money;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class ConverterSpec extends ObjectBehavior
+{
+    function let(Currencies $currencies)
+    {
+        $this->beConstructedWith($currencies);
+    }
+
+    /**
+     * @dataProvider convertExamples
+     */
+    function it_converts_to_a_different_currency($baseCurrencyCode, $counterCurrencyCode, $subunitBase, $subunitCounter, $ratio, $amount, $expectedAmount, Currencies $currencies)
+    {
+        $baseCurrency = new Currency($baseCurrencyCode);
+        $counterCurrency = new Currency($counterCurrencyCode);
+
+        $currencies->subunitFor($baseCurrency)->willReturn($subunitBase);
+        $currencies->subunitFor($counterCurrency)->willReturn($subunitCounter);
+
+        $money = $this->convert(
+            new Money($amount, new Currency($baseCurrencyCode)),
+            new CurrencyPair($baseCurrency, $counterCurrency, $ratio)
+        );
+
+        $money->shouldHaveType(Money::class);
+        $money->getAmount()->shouldBeLike($expectedAmount);
+        $money->getCurrency()->shouldBeLike($counterCurrencyCode);
+    }
+
+    function it_converts_using_rounding_modes(Currencies $currencies)
+    {
+        $baseCurrency = new Currency('EUR');
+        $counterCurrency = new Currency('USD');
+        $pair = new CurrencyPair($baseCurrency, $counterCurrency, 1.25);
+
+        $currencies->subunitFor($baseCurrency)->willReturn(2);
+        $currencies->subunitFor($counterCurrency)->willReturn(2);
+
+        $money = new Money(10, $baseCurrency);
+
+        $resultMoney = $this->convert($money, $pair);
+
+        $resultMoney->shouldHaveType(Money::class);
+        $resultMoney->getAmount()->shouldBeLike(13);
+        $resultMoney->getCurrency()->getCode()->shouldReturn('USD');
+
+        $resultMoney = $this->convert($money, $pair, PHP_ROUND_HALF_DOWN);
+
+        $resultMoney->shouldHaveType(Money::class);
+        $resultMoney->getAmount()->shouldBeLike(12);
+        $resultMoney->getCurrency()->getCode()->shouldReturn('USD');
+    }
+
+    public function convertExamples()
+    {
+        return [
+            ['USD', 'JPY', 2, 0, 101, 100, 101],
+            ['JPY', 'USD', 0, 2, 0.0099, 1000, 990],
+            ['USD', 'EUR', 2, 2, 0.89, 100, 89],
+            ['EUR', 'USD', 2, 2, 1.12, 100, 112],
+        ];
+    }
+}

--- a/spec/ConverterSpec.php
+++ b/spec/ConverterSpec.php
@@ -5,6 +5,7 @@ namespace spec\Money;
 use Money\Calculator;
 use Money\Currencies;
 use Money\Currency;
+use Money\CurrencyPair;
 use Money\Exchange;
 use Money\Money;
 use PhpSpec\ObjectBehavior;
@@ -33,11 +34,12 @@ class ConverterSpec extends ObjectBehavior
     ) {
         $baseCurrency = new Currency($baseCurrencyCode);
         $counterCurrency = new Currency($counterCurrencyCode);
+        $pair = new CurrencyPair($baseCurrency, $counterCurrency, $ratio);
 
         $currencies->subunitFor($baseCurrency)->willReturn($subunitBase);
         $currencies->subunitFor($counterCurrency)->willReturn($subunitCounter);
 
-        $exchange->quote($baseCurrency, $counterCurrency)->willReturn($ratio);
+        $exchange->quote($baseCurrency, $counterCurrency)->willReturn($pair);
 
         $money = $this->convert(
             new Money($amount, new Currency($baseCurrencyCode)),
@@ -53,10 +55,11 @@ class ConverterSpec extends ObjectBehavior
     {
         $baseCurrency = new Currency('EUR');
         $counterCurrency = new Currency('USD');
+        $pair = new CurrencyPair($baseCurrency, $counterCurrency, 1.25);
 
         $currencies->subunitFor($baseCurrency)->willReturn(2);
         $currencies->subunitFor($counterCurrency)->willReturn(2);
-        $exchange->quote($baseCurrency, $counterCurrency)->willReturn(1.25);
+        $exchange->quote($baseCurrency, $counterCurrency)->willReturn($pair);
 
         $money = new Money(10, $baseCurrency);
 

--- a/spec/CurrencyPairSpec.php
+++ b/spec/CurrencyPairSpec.php
@@ -42,34 +42,6 @@ class CurrencyPairSpec extends ObjectBehavior
         $this->shouldThrow(\InvalidArgumentException::class)->duringConvert($money);
     }
 
-    function it_converts_from_base_currency_to_counter()
-    {
-        $money = new Money(100, new Currency('EUR'));
-
-        $resultMoney = $this->convert($money);
-
-        $resultMoney->shouldHaveType(Money::class);
-        $resultMoney->getAmount()->shouldBeLike(125);
-        $resultMoney->getCurrency()->getCode()->shouldReturn('USD');
-    }
-
-    function it_converts_using_rounding_modes()
-    {
-        $money = new Money(10, new Currency('EUR'));
-
-        $resultMoney = $this->convert($money);
-
-        $resultMoney->shouldHaveType(Money::class);
-        $resultMoney->getAmount()->shouldBeLike(13);
-        $resultMoney->getCurrency()->getCode()->shouldReturn('USD');
-
-        $resultMoney = $this->convert($money, PHP_ROUND_HALF_DOWN);
-
-        $resultMoney->shouldHaveType(Money::class);
-        $resultMoney->getAmount()->shouldBeLike(12);
-        $resultMoney->getCurrency()->getCode()->shouldReturn('USD');
-    }
-
     /**
      * @dataProvider equalityExamples
      */

--- a/spec/Exchange/FixedExchangeSpec.php
+++ b/spec/Exchange/FixedExchangeSpec.php
@@ -4,10 +4,6 @@ namespace spec\Money\Exchange;
 
 use Money\Currency;
 use Money\Exception\UnresolvableCurrencyPairException;
-use Swap\Exception\Exception;
-use Swap\Model\CurrencyPair;
-use Swap\Model\Rate;
-use Swap\SwapInterface;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 

--- a/spec/Exchange/FixedExchangeSpec.php
+++ b/spec/Exchange/FixedExchangeSpec.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace spec\Money\Exchange;
+
+use Money\Currency;
+use Money\Exception\UnresolvableCurrencyPairException;
+use Swap\Exception\Exception;
+use Swap\Model\CurrencyPair;
+use Swap\Model\Rate;
+use Swap\SwapInterface;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class FixedExchangeSpec extends ObjectBehavior
+{
+    function let()
+    {
+        $this->beConstructedWith([
+            'EUR' => [
+                'USD' => 1.25
+            ]
+        ]);
+    }
+
+    function it_exchanges_currencies()
+    {
+        $baseCurrency = new Currency('EUR');
+        $counterCurrency = new Currency('USD');
+        $currencyPair = $this->quote($baseCurrency, $counterCurrency);
+
+        $currencyPair->shouldHaveType(\Money\CurrencyPair::class);
+        $currencyPair->getBaseCurrency()->shouldReturn($baseCurrency);
+        $currencyPair->getCounterCurrency()->shouldReturn($counterCurrency);
+        $currencyPair->getConversionRatio()->shouldReturn(1.25);
+    }
+
+    function it_cannot_exchange_currencies()
+    {
+        $this->shouldThrow(UnresolvableCurrencyPairException::class)
+            ->duringQuote(new Currency('USD'), $counter = new Currency('EUR'));
+    }
+}

--- a/spec/Exchange/SwapExchangeSpec.php
+++ b/spec/Exchange/SwapExchangeSpec.php
@@ -27,7 +27,7 @@ class SwapExchangeSpec extends ObjectBehavior
     {
         $swap->quote(Argument::type(CurrencyPair::class))->willReturn(new Rate(1.0));
 
-        $currencyPair = $this->getCurrencyPair($base = new Currency('EUR'), $counter = new Currency('USD'));
+        $currencyPair = $this->quote($base = new Currency('EUR'), $counter = new Currency('USD'));
 
         $currencyPair->shouldHaveType(\Money\CurrencyPair::class);
         $currencyPair->getBaseCurrency()->shouldReturn($base);
@@ -40,6 +40,6 @@ class SwapExchangeSpec extends ObjectBehavior
         $swap->quote(Argument::type(CurrencyPair::class))->willThrow(Exception::class);
 
         $this->shouldThrow(UnresolvableCurrencyPairException::class)
-            ->duringGetCurrencyPair(new Currency('EUR'), $counter = new Currency('USD'));
+            ->duringQuote(new Currency('EUR'), $counter = new Currency('USD'));
     }
 }

--- a/spec/MoneySpec.php
+++ b/spec/MoneySpec.php
@@ -190,19 +190,6 @@ class MoneySpec extends ObjectBehavior
         $this->shouldThrow(\InvalidArgumentException::class)->duringMultiply(1.0, 'INVALID_ROUNDING_MODE');
     }
 
-    function it_converts_to_a_different_currency(Calculator $calculator)
-    {
-        $this->beConstructedWith(100, new Currency(self::CURRENCY));
-
-        $calculator->multiply('100', 1.25)->willReturn(125);
-        $calculator->round(125, Money::ROUND_HALF_UP)->willReturn(125);
-
-        $money = $this->convert(new Currency('USD'), 1.25);
-
-        $money->shouldHaveType(Money::class);
-        $money->getAmount()->shouldBeLike(125);
-    }
-
     /**
      * @dataProvider roundExamples
      */

--- a/src/Converter.php
+++ b/src/Converter.php
@@ -21,6 +21,7 @@ final class Converter
      * @param Money        $money
      * @param CurrencyPair $currencyPair
      * @param int          $roundingMode
+     *
      * @return Money
      */
     public function convert(Money $money, CurrencyPair $currencyPair, $roundingMode = Money::ROUND_HALF_UP)

--- a/src/Converter.php
+++ b/src/Converter.php
@@ -3,7 +3,7 @@
 namespace Money;
 
 /**
- * Provides a way to convert Money to Money in another Currency using an exchange rate
+ * Provides a way to convert Money to Money in another Currency using an exchange rate.
  *
  * @author Márk Sági-Kazár <mark.sagikazar@gmail.com>
  */

--- a/src/Converter.php
+++ b/src/Converter.php
@@ -38,7 +38,7 @@ final class Converter
     public function convert(Money $money, Currency $counterCurrency, $roundingMode = Money::ROUND_HALF_UP)
     {
         $baseCurrency = $money->getCurrency();
-        $ratio = $this->exchange->quote($baseCurrency, $counterCurrency);
+        $ratio = $this->exchange->quote($baseCurrency, $counterCurrency)->getConversionRatio();
 
         $baseCurrencySubunit = $this->currencies->subunitFor($baseCurrency);
         $counterCurrencySubunit = $this->currencies->subunitFor($counterCurrency);

--- a/src/Converter.php
+++ b/src/Converter.php
@@ -46,9 +46,7 @@ final class Converter
 
         if ($subunitDifference > 0) {
             $ratio = $ratio / pow(10, $subunitDifference);
-        }
-
-        if ($subunitDifference < 0) {
+        } elseif ($subunitDifference < 0) {
             $ratio = $ratio * pow(10, abs($subunitDifference));
         }
 

--- a/src/Converter.php
+++ b/src/Converter.php
@@ -5,7 +5,7 @@ namespace Money;
 /**
  * Provides a way to convert Money to Money in another Currency using an exchange rate.
  *
- * @author Márk Sági-Kazár <mark.sagikazar@gmail.com>
+ * @author Frederik Bosch <f.bosch@genkgo.nl>
  */
 final class Converter
 {

--- a/src/Converter.php
+++ b/src/Converter.php
@@ -29,9 +29,9 @@ final class Converter
     }
 
     /**
-     * @param Money        $money
-     * @param Currency     $counterCurrency
-     * @param int          $roundingMode
+     * @param Money    $money
+     * @param Currency $counterCurrency
+     * @param int      $roundingMode
      *
      * @return Money
      */

--- a/src/Converter.php
+++ b/src/Converter.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Money;
+
+final class Converter
+{
+    /**
+     * @var Currencies
+     */
+    private $currencies;
+
+    /**
+     * @param Currencies $currencies
+     */
+    public function __construct(Currencies $currencies)
+    {
+        $this->currencies = $currencies;
+    }
+
+    /**
+     * @param Money        $money
+     * @param CurrencyPair $currencyPair
+     * @param int          $roundingMode
+     * @return Money
+     */
+    public function convert(Money $money, CurrencyPair $currencyPair, $roundingMode = Money::ROUND_HALF_UP)
+    {
+        if ($money->getCurrency()->getCode() !== $currencyPair->getBaseCurrency()->getCode()) {
+            throw new \InvalidArgumentException('Base Currency of currency pair does not equal money currency');
+        }
+
+        $subunitBaseCurrency = $this->currencies->subunitFor($currencyPair->getBaseCurrency());
+        $subunitCounterCurrency = $this->currencies->subunitFor($currencyPair->getCounterCurrency());
+        $differenceInSubunit = $subunitBaseCurrency - $subunitCounterCurrency;
+        $ratio = $currencyPair->getConversionRatio();
+
+        if ($differenceInSubunit > 0) {
+            $ratio = $ratio / pow(10, $differenceInSubunit);
+        }
+
+        if ($differenceInSubunit < 0) {
+            $ratio = $ratio * pow(10, abs($differenceInSubunit));
+        }
+
+        $counterValue = $money->multiply($ratio, $roundingMode);
+
+        return new Money($counterValue->getAmount(), $currencyPair->getCounterCurrency());
+    }
+}

--- a/src/Exchange.php
+++ b/src/Exchange.php
@@ -21,5 +21,5 @@ interface Exchange
      *
      * @throws UnresolvableCurrencyPairException When there is no currency pair (rate) available for the given currencies
      */
-    public function getCurrencyPair(Currency $baseCurrency, Currency $counterCurrency);
+    public function quote(Currency $baseCurrency, Currency $counterCurrency);
 }

--- a/src/Exchange/FixedExchange.php
+++ b/src/Exchange/FixedExchange.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Money\Exchange;
+
+use Money\Currency;
+use Money\CurrencyPair;
+use Money\Exception\UnresolvableCurrencyPairException;
+use Money\Exchange;
+
+/**
+ * Provides a way to get exchange rate from a static list (array).
+ *
+ * @author Frederik Bosch <f.bosch@genkgo.nl>
+ */
+final class FixedExchange implements Exchange
+{
+    /**
+     * @var array
+     */
+    private $list;
+
+    /**
+     * @param array $list
+     */
+    public function __construct(array $list)
+    {
+        $this->list = $list;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function quote(Currency $baseCurrency, Currency $counterCurrency)
+    {
+        if (isset($this->list[$baseCurrency->getCode()][$counterCurrency->getCode()])) {
+            return new CurrencyPair(
+                $baseCurrency,
+                $counterCurrency,
+                $this->list[$baseCurrency->getCode()][$counterCurrency->getCode()]
+            );
+        }
+
+        throw UnresolvableCurrencyPairException::createFromCurrencies($baseCurrency, $counterCurrency);
+    }
+}

--- a/src/Exchange/SwapExchange.php
+++ b/src/Exchange/SwapExchange.php
@@ -33,7 +33,7 @@ final class SwapExchange implements Exchange
     /**
      * {@inheritdoc}
      */
-    public function getCurrencyPair(Currency $baseCurrency, Currency $counterCurrency)
+    public function quote(Currency $baseCurrency, Currency $counterCurrency)
     {
         $swapCurrencyPair = new SwapCurrencyPair($baseCurrency->getCode(), $counterCurrency->getCode());
 

--- a/src/Money.php
+++ b/src/Money.php
@@ -303,21 +303,6 @@ final class Money implements \JsonSerializable
     }
 
     /**
-     * @param Currency  $targetCurrency
-     * @param float|int $conversionRate
-     * @param int       $roundingMode
-     *
-     * @return Money
-     */
-    public function convert(Currency $targetCurrency, $conversionRate, $roundingMode = self::ROUND_HALF_UP)
-    {
-        $this->assertRoundingMode($roundingMode);
-        $amount = $this->getCalculator()->round($this->getCalculator()->multiply($this->amount, $conversionRate), $roundingMode);
-
-        return new self($amount, $targetCurrency);
-    }
-
-    /**
      * Returns a new Money object that represents
      * the divided value by the given factor.
      *


### PR DESCRIPTION
I chose the method of a new class `Converter`. Also renamed `getCurrencyPair` to `quote`, because I feel that is better name. Don't ask but tell. Happy to change it again if that is what we want.