### PR TITLE
Add USD, EUR and GPB as static methods to the PHPDoc block

### DIFF
--- a/src/Money.php
+++ b/src/Money.php
@@ -7,9 +7,9 @@ namespace Money;
  *
  * @author Mathias Verraes
  *
- * @method static \Money\Money USD()
- * @method static \Money\Money EUR()
- * @method static \Money\Money GPB()
+ * @method static \Money\Money USD($value)
+ * @method static \Money\Money EUR($value)
+ * @method static \Money\Money GPB($value)
  */
 final class Money implements \JsonSerializable
 {

--- a/src/Money.php
+++ b/src/Money.php
@@ -6,6 +6,10 @@ namespace Money;
  * Money Value Object.
  *
  * @author Mathias Verraes
+ *
+ * @method static \Money\Money USD()
+ * @method static \Money\Money EUR()
+ * @method static \Money\Money GPB()
  */
 final class Money implements \JsonSerializable
 {


### PR DESCRIPTION
Documenting dynamically appended static methods helps IDEs (like PHPStorm) to understand that these static methods are valid methods (for autocompletion and error detection). I'd at least add the most common currencies to the PHPDoc header for the `Money` class.