### PR TITLE
Add DecimalMoneyFormatter

### DIFF
--- a/doc/Formatting.rst
+++ b/doc/Formatting.rst
@@ -10,7 +10,7 @@ Money comes with the following implementations out of the box:
 Intl Formatter
 --------------
 
-As it's name says, this formatter requires the `intl` extension and uses ``NumberFormatter``. In order to provide the
+As its name says, this formatter requires the `intl` extension and uses ``NumberFormatter``. In order to provide the
 correct subunit for the specific currency, you should also provide the specific currency repository.
 
 
@@ -32,6 +32,28 @@ correct subunit for the specific currency, you should also provide the specific 
     $moneyFormatter = new IntlMoneyFormatter($numberFormatter, $currencies);
 
     echo $moneyFormatter->format($money); // outputs $1.00
+
+
+Decimal Formatter
+-----------------
+
+This formatter outputs a simple decimal string which is always in a consistent format independent of locale. In order
+to provide the correct subunit for the specific currency, you should provide the specific currency repository.
+
+
+.. code-block:: php
+
+    use Money\Currencies\ISOCurrencies;
+    use Money\Currency;
+    use Money\Formatter\DecimalMoneyFormatter;
+    use Money\Money;
+
+    $money = new Money(100, new Currency('USD'));
+    $currencies = new ISOCurrencies();
+
+    $moneyFormatter = new DecimalMoneyFormatter($currencies);
+
+    echo $moneyFormatter->format($money); // outputs 1.00
 
 
 Aggregate Formatter

--- a/spec/Formatter/DecimalMoneyFormatterSpec.php
+++ b/spec/Formatter/DecimalMoneyFormatterSpec.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace spec\Money\Formatter;
+
+use Money\Currencies;
+use Money\Currency;
+use Money\Money;
+use Money\MoneyFormatter;
+use PhpSpec\ObjectBehavior;
+
+class DecimalMoneyFormatterSpec extends ObjectBehavior
+{
+    function let(Currencies $currencies)
+    {
+        $this->beConstructedWith($currencies);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Money\Formatter\DecimalMoneyFormatter');
+    }
+
+    function it_is_a_money_formatter()
+    {
+        $this->shouldImplement(MoneyFormatter::class);
+    }
+
+    function it_formats_money(Currencies $currencies)
+    {
+        $money = new Money(100, new Currency('EUR'));
+
+        $currencies->subunitFor($money->getCurrency())->willReturn(2);
+
+        $this->format($money)->shouldReturn('1.00');
+    }
+}

--- a/src/Formatter/DecimalMoneyFormatter.php
+++ b/src/Formatter/DecimalMoneyFormatter.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Money\Formatter;
+
+use Money\Currencies;
+use Money\Money;
+use Money\MoneyFormatter;
+
+/**
+ * Formats a Money object as a decimal string.
+ *
+ * @author Teoh Han Hui <teohhanhui@gmail.com>
+ */
+final class DecimalMoneyFormatter implements MoneyFormatter
+{
+    /**
+     * @var Currencies
+     */
+    private $currencies;
+
+    /**
+     * @param Currencies $currencies
+     */
+    public function __construct(Currencies $currencies)
+    {
+        $this->currencies = $currencies;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function format(Money $money)
+    {
+        $valueBase = $money->getAmount();
+        $negative = false;
+
+        if ($valueBase[0] === '-') {
+            $negative = true;
+            $valueBase = substr($valueBase, 1);
+        }
+
+        $subunit = $this->currencies->subunitFor($money->getCurrency());
+        $valueLength = strlen($valueBase);
+
+        if ($valueLength > $subunit) {
+            $formatted = substr($valueBase, 0, $valueLength - $subunit).'.';
+            $formatted .= substr($valueBase, $valueLength - $subunit);
+        } else {
+            $formatted = '0.'.str_pad('', $subunit - $valueLength, '0').$valueBase;
+        }
+
+        if ($negative === true) {
+            $formatted = '-'.$formatted;
+        }
+
+        return $formatted;
+    }
+}

--- a/tests/Formatter/DecimalMoneyFormatterTest.php
+++ b/tests/Formatter/DecimalMoneyFormatterTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Tests\Money\Formatter;
+
+use Money\Currencies;
+use Money\Currency;
+use Money\Formatter\DecimalMoneyFormatter;
+use Money\Money;
+use Prophecy\Argument;
+
+final class DecimalMoneyFormatterTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider numberFormatterExamples
+     */
+    public function testNumberFormatter($amount, $currency, $subunit, $result)
+    {
+        $money = new Money($amount, new Currency($currency));
+
+        $currenciesProphecy = $this->prophesize(Currencies::class);
+        $currenciesProphecy->contains(Argument::allOf(
+            Argument::type(Currency::class),
+            Argument::which('getCode', $currency)
+        ))->willReturn(true);
+        $currenciesProphecy->subunitFor(Argument::allOf(
+            Argument::type(Currency::class),
+            Argument::which('getCode', $currency)
+        ))->willReturn($subunit);
+        $currencies = $currenciesProphecy->reveal();
+
+        $moneyFormatter = new DecimalMoneyFormatter($currencies);
+        $this->assertEquals($result, $moneyFormatter->format($money));
+    }
+
+    public static function numberFormatterExamples()
+    {
+        return [
+            [5005, 'USD', 2, '50.05'],
+            [100, 'USD', 2, '1.00'],
+            [41, 'USD', 2, '0.41'],
+            [5, 'USD', 2, '0.05'],
+            [50, 'USD', 3, '0.050'],
+            [350, 'USD', 3, '0.350'],
+            [1357, 'USD', 3, '1.357'],
+            [61351, 'USD', 3, '61.351'],
+            [-61351, 'USD', 3, '-61.351'],
+            [-6152, 'USD', 2, '-61.52'],
+            [5, 'JPY', 0, '5'],
+            [50, 'JPY', 0, '50'],
+            [500, 'JPY', 0, '500'],
+            [-5055, 'JPY', 0, '-5055'],
+            [5, 'JPY', 2, '0.05'],
+            [50, 'JPY', 2, '0.50'],
+            [500, 'JPY', 2, '5.00'],
+            [-5055, 'JPY', 2, '-50.55'],
+            [50050050, 'USD', 2, '500500.50'],
+        ];
+    }
+}


### PR DESCRIPTION
This formatter outputs a simple decimal string which is always in a consistent format independent of locale.

Related: #78

The workaround in https://github.com/moneyphp/money/issues/78#issuecomment-202262198 is inadequate now that we have subunits.

@sagikazarmark I hope this is not just "convenience stuff"?