### PR TITLE
Ignore the fractional part after validating it is full of zeroes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 
 - Reversed Currencies Exchange to try resolving reverse of a currency pair
 
+### Fixed
+
+- Money constructed from a string with fractional zeroes equals to a Money constructed without the fractional part (eg. `'5.00'` and `'5'`)
+
 
 ## 3.0.0 - 2016-10-26
 

--- a/spec/MoneySpec.php
+++ b/spec/MoneySpec.php
@@ -81,6 +81,12 @@ final class MoneySpec extends ObjectBehavior
         $this->equals(new Money(self::AMOUNT, new Currency(self::CURRENCY)))->shouldReturn(true);
     }
 
+    function it_equals_to_money_costructed_with_fractional_part_of_zeroes()
+    {
+        $amountWithFractionalPart = sprintf('%d.00', self::AMOUNT);
+        $this->equals(new Money($amountWithFractionalPart, new Currency(self::CURRENCY)))->shouldReturn(true);
+    }
+
     function it_compares_two_amounts(Calculator $calculator)
     {
         $calculator->compare((string) self::AMOUNT, (string) self::AMOUNT)->willReturn(0);

--- a/src/Money.php
+++ b/src/Money.php
@@ -56,8 +56,12 @@ final class Money implements \JsonSerializable
      */
     public function __construct($amount, Currency $currency)
     {
-        if (filter_var($amount, FILTER_VALIDATE_INT) === false && !Number::fromString($amount)->isInteger()) {
-            throw new \InvalidArgumentException('Amount must be an integer(ish) value');
+        if (filter_var($amount, FILTER_VALIDATE_INT) === false) {
+            $numberFromString = Number::fromString($amount);
+            if (!$numberFromString->isInteger()) {
+                throw new \InvalidArgumentException('Amount must be an integer(ish) value');
+            }
+            $amount = $numberFromString->getIntegerPart();
         }
 
         $this->amount = (string) $amount;


### PR DESCRIPTION
Code example:

```php
$amountA = new Money(5, new Currency('CZK'));
$amountB = new Money('5.00', new Currency('CZK'));

var_dump($amountA->compare($amountB));
var_dump($amountA->equals($amountB));
```

Expected output:

```
int(0)
bool(true)
```

Actual output:

```
int(0)
bool(false)
```