### PR TITLE
Fix values in comparison examples

### DIFF
--- a/doc/features/comparison.rst
+++ b/doc/features/comparison.rst
@@ -45,7 +45,7 @@ Greater Than
 .. code-block:: php
 
     $value1 = Money::USD(800);                  // $8.00
-    $value2 = Money::USD(700);                  // $8.00
+    $value2 = Money::USD(700);                  // $7.00
 
     $result = $value1->greaterThan($value2);    // true
 
@@ -68,7 +68,7 @@ Less Than
 .. code-block:: php
 
     $value1 = Money::USD(800);              // $8.00
-    $value2 = Money::USD(700);              // $8.00
+    $value2 = Money::USD(700);              // $7.00
 
     $result = $value1->lessThan($value2);   // false
 


### PR DESCRIPTION
In the [documentation page about comparison](http://moneyphp.org/en/latest/features/comparison.html) of Money objects, two examples have an inconsistency between the real value and the value that is specified in the accompanying comment. This PR simply fixes that.