### PR TITLE
Correct two old mentions of integer amounts to strings

### DIFF
--- a/src/Formatter/IntlMoneyFormatter.php
+++ b/src/Formatter/IntlMoneyFormatter.php
@@ -38,7 +38,7 @@ final class IntlMoneyFormatter implements MoneyFormatter
      */
     public function format(Money $money)
     {
-        $valueBase = (string) $money->getAmount();
+        $valueBase = $money->getAmount();
         $negative = false;
 
         if ($valueBase[0] === '-') {

--- a/src/Money.php
+++ b/src/Money.php
@@ -25,7 +25,7 @@ final class Money implements \JsonSerializable
     /**
      * Internal value.
      *
-     * @var int
+     * @var string
      */
     private $amount;
 


### PR DESCRIPTION
I found a couple of places which weren't updated when internal amounts were changed from ints to strings.