### PR TITLE
Remove blank currency from ISOCurrencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Change Log
 
+## 3.0.4 - 2017-04-20
+
+### Fixed
+
+- ISOCurrencies will no longer have a blank currency
+
+### Changed
+
+- Updated ISO Currencies
+- Removed old Belarusian ruble from ISOCurrencies (BYR)
+
 ## 3.0.3 - 2017-03-22
 
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "cache/taggable-cache": "^0.4.0",
         "phpspec/phpspec": "^2.5",
         "henrikbjorn/phpspec-code-coverage": "^2.0.2",
-        "moneyphp/iso-currencies": "^1.0",
+        "moneyphp/iso-currencies": "^3.0",
         "sllh/php-cs-fixer-styleci-bridge": "^2.1",
         "php-http/message": "^1.4",
         "php-http/mock-client": "^0.3.3"

--- a/resources/currency.php
+++ b/resources/currency.php
@@ -3,7 +3,6 @@
   array (
     'alphabeticCode' => 'AFN',
     'currency' => 'Afghani',
-    'entity' => 'AFGHANISTAN',
     'minorUnit' => 2,
     'numericCode' => 971,
   ),
@@ -11,7 +10,6 @@
   array (
     'alphabeticCode' => 'EUR',
     'currency' => 'Euro',
-    'entity' => 'SPAIN',
     'minorUnit' => 2,
     'numericCode' => 978,
   ),
@@ -19,7 +17,6 @@
   array (
     'alphabeticCode' => 'ALL',
     'currency' => 'Lek',
-    'entity' => 'ALBANIA',
     'minorUnit' => 2,
     'numericCode' => 8,
   ),
@@ -27,7 +24,6 @@
   array (
     'alphabeticCode' => 'DZD',
     'currency' => 'Algerian Dinar',
-    'entity' => 'ALGERIA',
     'minorUnit' => 2,
     'numericCode' => 12,
   ),
@@ -35,7 +31,6 @@
   array (
     'alphabeticCode' => 'USD',
     'currency' => 'US Dollar',
-    'entity' => 'VIRGIN ISLANDS (U.S.)',
     'minorUnit' => 2,
     'numericCode' => 840,
   ),
@@ -43,7 +38,6 @@
   array (
     'alphabeticCode' => 'AOA',
     'currency' => 'Kwanza',
-    'entity' => 'ANGOLA',
     'minorUnit' => 2,
     'numericCode' => 973,
   ),
@@ -51,23 +45,13 @@
   array (
     'alphabeticCode' => 'XCD',
     'currency' => 'East Caribbean Dollar',
-    'entity' => 'SAINT VINCENT AND THE GRENADINES',
     'minorUnit' => 2,
     'numericCode' => 951,
-  ),
-  '' => 
-  array (
-    'alphabeticCode' => '',
-    'currency' => 'No universal currency',
-    'entity' => 'SOUTH GEORGIA AND THE SOUTH SANDWICH ISLANDS',
-    'minorUnit' => 0,
-    'numericCode' => 0,
   ),
   'ARS' => 
   array (
     'alphabeticCode' => 'ARS',
     'currency' => 'Argentine Peso',
-    'entity' => 'ARGENTINA',
     'minorUnit' => 2,
     'numericCode' => 32,
   ),
@@ -75,7 +59,6 @@
   array (
     'alphabeticCode' => 'AMD',
     'currency' => 'Armenian Dram',
-    'entity' => 'ARMENIA',
     'minorUnit' => 2,
     'numericCode' => 51,
   ),
@@ -83,7 +66,6 @@
   array (
     'alphabeticCode' => 'AWG',
     'currency' => 'Aruban Florin',
-    'entity' => 'ARUBA',
     'minorUnit' => 2,
     'numericCode' => 533,
   ),
@@ -91,7 +73,6 @@
   array (
     'alphabeticCode' => 'AUD',
     'currency' => 'Australian Dollar',
-    'entity' => 'TUVALU',
     'minorUnit' => 2,
     'numericCode' => 36,
   ),
@@ -99,7 +80,6 @@
   array (
     'alphabeticCode' => 'AZN',
     'currency' => 'Azerbaijanian Manat',
-    'entity' => 'AZERBAIJAN',
     'minorUnit' => 2,
     'numericCode' => 944,
   ),
@@ -107,7 +87,6 @@
   array (
     'alphabeticCode' => 'BSD',
     'currency' => 'Bahamian Dollar',
-    'entity' => 'BAHAMAS (THE)',
     'minorUnit' => 2,
     'numericCode' => 44,
   ),
@@ -115,7 +94,6 @@
   array (
     'alphabeticCode' => 'BHD',
     'currency' => 'Bahraini Dinar',
-    'entity' => 'BAHRAIN',
     'minorUnit' => 3,
     'numericCode' => 48,
   ),
@@ -123,7 +101,6 @@
   array (
     'alphabeticCode' => 'BDT',
     'currency' => 'Taka',
-    'entity' => 'BANGLADESH',
     'minorUnit' => 2,
     'numericCode' => 50,
   ),
@@ -131,7 +108,6 @@
   array (
     'alphabeticCode' => 'BBD',
     'currency' => 'Barbados Dollar',
-    'entity' => 'BARBADOS',
     'minorUnit' => 2,
     'numericCode' => 52,
   ),
@@ -139,23 +115,13 @@
   array (
     'alphabeticCode' => 'BYN',
     'currency' => 'Belarusian Ruble',
-    'entity' => 'BELARUS',
     'minorUnit' => 2,
     'numericCode' => 933,
-  ),
-  'BYR' => 
-  array (
-    'alphabeticCode' => 'BYR',
-    'currency' => 'Belarusian Ruble',
-    'entity' => 'BELARUS',
-    'minorUnit' => 0,
-    'numericCode' => 974,
   ),
   'BZD' => 
   array (
     'alphabeticCode' => 'BZD',
     'currency' => 'Belize Dollar',
-    'entity' => 'BELIZE',
     'minorUnit' => 2,
     'numericCode' => 84,
   ),
@@ -163,7 +129,6 @@
   array (
     'alphabeticCode' => 'XOF',
     'currency' => 'CFA Franc BCEAO',
-    'entity' => 'TOGO',
     'minorUnit' => 0,
     'numericCode' => 952,
   ),
@@ -171,7 +136,6 @@
   array (
     'alphabeticCode' => 'BMD',
     'currency' => 'Bermudian Dollar',
-    'entity' => 'BERMUDA',
     'minorUnit' => 2,
     'numericCode' => 60,
   ),
@@ -179,7 +143,6 @@
   array (
     'alphabeticCode' => 'INR',
     'currency' => 'Indian Rupee',
-    'entity' => 'INDIA',
     'minorUnit' => 2,
     'numericCode' => 356,
   ),
@@ -187,7 +150,6 @@
   array (
     'alphabeticCode' => 'BTN',
     'currency' => 'Ngultrum',
-    'entity' => 'BHUTAN',
     'minorUnit' => 2,
     'numericCode' => 64,
   ),
@@ -195,7 +157,6 @@
   array (
     'alphabeticCode' => 'BOB',
     'currency' => 'Boliviano',
-    'entity' => 'BOLIVIA (PLURINATIONAL STATE OF)',
     'minorUnit' => 2,
     'numericCode' => 68,
   ),
@@ -203,7 +164,6 @@
   array (
     'alphabeticCode' => 'BOV',
     'currency' => 'Mvdol',
-    'entity' => 'BOLIVIA (PLURINATIONAL STATE OF)',
     'minorUnit' => 2,
     'numericCode' => 984,
   ),
@@ -211,7 +171,6 @@
   array (
     'alphabeticCode' => 'BAM',
     'currency' => 'Convertible Mark',
-    'entity' => 'BOSNIA AND HERZEGOVINA',
     'minorUnit' => 2,
     'numericCode' => 977,
   ),
@@ -219,7 +178,6 @@
   array (
     'alphabeticCode' => 'BWP',
     'currency' => 'Pula',
-    'entity' => 'BOTSWANA',
     'minorUnit' => 2,
     'numericCode' => 72,
   ),
@@ -227,7 +185,6 @@
   array (
     'alphabeticCode' => 'NOK',
     'currency' => 'Norwegian Krone',
-    'entity' => 'SVALBARD AND JAN MAYEN',
     'minorUnit' => 2,
     'numericCode' => 578,
   ),
@@ -235,7 +192,6 @@
   array (
     'alphabeticCode' => 'BRL',
     'currency' => 'Brazilian Real',
-    'entity' => 'BRAZIL',
     'minorUnit' => 2,
     'numericCode' => 986,
   ),
@@ -243,7 +199,6 @@
   array (
     'alphabeticCode' => 'BND',
     'currency' => 'Brunei Dollar',
-    'entity' => 'BRUNEI DARUSSALAM',
     'minorUnit' => 2,
     'numericCode' => 96,
   ),
@@ -251,7 +206,6 @@
   array (
     'alphabeticCode' => 'BGN',
     'currency' => 'Bulgarian Lev',
-    'entity' => 'BULGARIA',
     'minorUnit' => 2,
     'numericCode' => 975,
   ),
@@ -259,7 +213,6 @@
   array (
     'alphabeticCode' => 'BIF',
     'currency' => 'Burundi Franc',
-    'entity' => 'BURUNDI',
     'minorUnit' => 0,
     'numericCode' => 108,
   ),
@@ -267,7 +220,6 @@
   array (
     'alphabeticCode' => 'CVE',
     'currency' => 'Cabo Verde Escudo',
-    'entity' => 'CABO VERDE',
     'minorUnit' => 2,
     'numericCode' => 132,
   ),
@@ -275,7 +227,6 @@
   array (
     'alphabeticCode' => 'KHR',
     'currency' => 'Riel',
-    'entity' => 'CAMBODIA',
     'minorUnit' => 2,
     'numericCode' => 116,
   ),
@@ -283,7 +234,6 @@
   array (
     'alphabeticCode' => 'XAF',
     'currency' => 'CFA Franc BEAC',
-    'entity' => 'GABON',
     'minorUnit' => 0,
     'numericCode' => 950,
   ),
@@ -291,7 +241,6 @@
   array (
     'alphabeticCode' => 'CAD',
     'currency' => 'Canadian Dollar',
-    'entity' => 'CANADA',
     'minorUnit' => 2,
     'numericCode' => 124,
   ),
@@ -299,7 +248,6 @@
   array (
     'alphabeticCode' => 'KYD',
     'currency' => 'Cayman Islands Dollar',
-    'entity' => 'CAYMAN ISLANDS (THE)',
     'minorUnit' => 2,
     'numericCode' => 136,
   ),
@@ -307,7 +255,6 @@
   array (
     'alphabeticCode' => 'CLP',
     'currency' => 'Chilean Peso',
-    'entity' => 'CHILE',
     'minorUnit' => 0,
     'numericCode' => 152,
   ),
@@ -315,7 +262,6 @@
   array (
     'alphabeticCode' => 'CLF',
     'currency' => 'Unidad de Fomento',
-    'entity' => 'CHILE',
     'minorUnit' => 4,
     'numericCode' => 990,
   ),
@@ -323,7 +269,6 @@
   array (
     'alphabeticCode' => 'CNY',
     'currency' => 'Yuan Renminbi',
-    'entity' => 'CHINA',
     'minorUnit' => 2,
     'numericCode' => 156,
   ),
@@ -331,7 +276,6 @@
   array (
     'alphabeticCode' => 'COP',
     'currency' => 'Colombian Peso',
-    'entity' => 'COLOMBIA',
     'minorUnit' => 2,
     'numericCode' => 170,
   ),
@@ -339,7 +283,6 @@
   array (
     'alphabeticCode' => 'COU',
     'currency' => 'Unidad de Valor Real',
-    'entity' => 'COLOMBIA',
     'minorUnit' => 2,
     'numericCode' => 970,
   ),
@@ -347,7 +290,6 @@
   array (
     'alphabeticCode' => 'KMF',
     'currency' => 'Comoro Franc',
-    'entity' => 'COMOROS (THE)',
     'minorUnit' => 0,
     'numericCode' => 174,
   ),
@@ -355,7 +297,6 @@
   array (
     'alphabeticCode' => 'CDF',
     'currency' => 'Congolese Franc',
-    'entity' => 'CONGO (THE DEMOCRATIC REPUBLIC OF THE)',
     'minorUnit' => 2,
     'numericCode' => 976,
   ),
@@ -363,7 +304,6 @@
   array (
     'alphabeticCode' => 'NZD',
     'currency' => 'New Zealand Dollar',
-    'entity' => 'TOKELAU',
     'minorUnit' => 2,
     'numericCode' => 554,
   ),
@@ -371,7 +311,6 @@
   array (
     'alphabeticCode' => 'CRC',
     'currency' => 'Costa Rican Colon',
-    'entity' => 'COSTA RICA',
     'minorUnit' => 2,
     'numericCode' => 188,
   ),
@@ -379,7 +318,6 @@
   array (
     'alphabeticCode' => 'HRK',
     'currency' => 'Kuna',
-    'entity' => 'CROATIA',
     'minorUnit' => 2,
     'numericCode' => 191,
   ),
@@ -387,7 +325,6 @@
   array (
     'alphabeticCode' => 'CUP',
     'currency' => 'Cuban Peso',
-    'entity' => 'CUBA',
     'minorUnit' => 2,
     'numericCode' => 192,
   ),
@@ -395,7 +332,6 @@
   array (
     'alphabeticCode' => 'CUC',
     'currency' => 'Peso Convertible',
-    'entity' => 'CUBA',
     'minorUnit' => 2,
     'numericCode' => 931,
   ),
@@ -403,7 +339,6 @@
   array (
     'alphabeticCode' => 'ANG',
     'currency' => 'Netherlands Antillean Guilder',
-    'entity' => 'SINT MAARTEN (DUTCH PART)',
     'minorUnit' => 2,
     'numericCode' => 532,
   ),
@@ -411,7 +346,6 @@
   array (
     'alphabeticCode' => 'CZK',
     'currency' => 'Czech Koruna',
-    'entity' => 'CZECH REPUBLIC (THE)',
     'minorUnit' => 2,
     'numericCode' => 203,
   ),
@@ -419,7 +353,6 @@
   array (
     'alphabeticCode' => 'DKK',
     'currency' => 'Danish Krone',
-    'entity' => 'GREENLAND',
     'minorUnit' => 2,
     'numericCode' => 208,
   ),
@@ -427,7 +360,6 @@
   array (
     'alphabeticCode' => 'DJF',
     'currency' => 'Djibouti Franc',
-    'entity' => 'DJIBOUTI',
     'minorUnit' => 0,
     'numericCode' => 262,
   ),
@@ -435,7 +367,6 @@
   array (
     'alphabeticCode' => 'DOP',
     'currency' => 'Dominican Peso',
-    'entity' => 'DOMINICAN REPUBLIC (THE)',
     'minorUnit' => 2,
     'numericCode' => 214,
   ),
@@ -443,7 +374,6 @@
   array (
     'alphabeticCode' => 'EGP',
     'currency' => 'Egyptian Pound',
-    'entity' => 'EGYPT',
     'minorUnit' => 2,
     'numericCode' => 818,
   ),
@@ -451,7 +381,6 @@
   array (
     'alphabeticCode' => 'SVC',
     'currency' => 'El Salvador Colon',
-    'entity' => 'EL SALVADOR',
     'minorUnit' => 2,
     'numericCode' => 222,
   ),
@@ -459,7 +388,6 @@
   array (
     'alphabeticCode' => 'ERN',
     'currency' => 'Nakfa',
-    'entity' => 'ERITREA',
     'minorUnit' => 2,
     'numericCode' => 232,
   ),
@@ -467,7 +395,6 @@
   array (
     'alphabeticCode' => 'ETB',
     'currency' => 'Ethiopian Birr',
-    'entity' => 'ETHIOPIA',
     'minorUnit' => 2,
     'numericCode' => 230,
   ),
@@ -475,7 +402,6 @@
   array (
     'alphabeticCode' => 'FKP',
     'currency' => 'Falkland Islands Pound',
-    'entity' => 'FALKLAND ISLANDS (THE) [MALVINAS]',
     'minorUnit' => 2,
     'numericCode' => 238,
   ),
@@ -483,7 +409,6 @@
   array (
     'alphabeticCode' => 'FJD',
     'currency' => 'Fiji Dollar',
-    'entity' => 'FIJI',
     'minorUnit' => 2,
     'numericCode' => 242,
   ),
@@ -491,7 +416,6 @@
   array (
     'alphabeticCode' => 'XPF',
     'currency' => 'CFP Franc',
-    'entity' => 'WALLIS AND FUTUNA',
     'minorUnit' => 0,
     'numericCode' => 953,
   ),
@@ -499,7 +423,6 @@
   array (
     'alphabeticCode' => 'GMD',
     'currency' => 'Dalasi',
-    'entity' => 'GAMBIA (THE)',
     'minorUnit' => 2,
     'numericCode' => 270,
   ),
@@ -507,7 +430,6 @@
   array (
     'alphabeticCode' => 'GEL',
     'currency' => 'Lari',
-    'entity' => 'GEORGIA',
     'minorUnit' => 2,
     'numericCode' => 981,
   ),
@@ -515,7 +437,6 @@
   array (
     'alphabeticCode' => 'GHS',
     'currency' => 'Ghana Cedi',
-    'entity' => 'GHANA',
     'minorUnit' => 2,
     'numericCode' => 936,
   ),
@@ -523,7 +444,6 @@
   array (
     'alphabeticCode' => 'GIP',
     'currency' => 'Gibraltar Pound',
-    'entity' => 'GIBRALTAR',
     'minorUnit' => 2,
     'numericCode' => 292,
   ),
@@ -531,7 +451,6 @@
   array (
     'alphabeticCode' => 'GTQ',
     'currency' => 'Quetzal',
-    'entity' => 'GUATEMALA',
     'minorUnit' => 2,
     'numericCode' => 320,
   ),
@@ -539,7 +458,6 @@
   array (
     'alphabeticCode' => 'GBP',
     'currency' => 'Pound Sterling',
-    'entity' => 'UNITED KINGDOM OF GREAT BRITAIN AND NORTHERN IRELAND (THE)',
     'minorUnit' => 2,
     'numericCode' => 826,
   ),
@@ -547,7 +465,6 @@
   array (
     'alphabeticCode' => 'GNF',
     'currency' => 'Guinea Franc',
-    'entity' => 'GUINEA',
     'minorUnit' => 0,
     'numericCode' => 324,
   ),
@@ -555,7 +472,6 @@
   array (
     'alphabeticCode' => 'GYD',
     'currency' => 'Guyana Dollar',
-    'entity' => 'GUYANA',
     'minorUnit' => 2,
     'numericCode' => 328,
   ),
@@ -563,7 +479,6 @@
   array (
     'alphabeticCode' => 'HTG',
     'currency' => 'Gourde',
-    'entity' => 'HAITI',
     'minorUnit' => 2,
     'numericCode' => 332,
   ),
@@ -571,7 +486,6 @@
   array (
     'alphabeticCode' => 'HNL',
     'currency' => 'Lempira',
-    'entity' => 'HONDURAS',
     'minorUnit' => 2,
     'numericCode' => 340,
   ),
@@ -579,7 +493,6 @@
   array (
     'alphabeticCode' => 'HKD',
     'currency' => 'Hong Kong Dollar',
-    'entity' => 'HONG KONG',
     'minorUnit' => 2,
     'numericCode' => 344,
   ),
@@ -587,7 +500,6 @@
   array (
     'alphabeticCode' => 'HUF',
     'currency' => 'Forint',
-    'entity' => 'HUNGARY',
     'minorUnit' => 2,
     'numericCode' => 348,
   ),
@@ -595,7 +507,6 @@
   array (
     'alphabeticCode' => 'ISK',
     'currency' => 'Iceland Krona',
-    'entity' => 'ICELAND',
     'minorUnit' => 0,
     'numericCode' => 352,
   ),
@@ -603,7 +514,6 @@
   array (
     'alphabeticCode' => 'IDR',
     'currency' => 'Rupiah',
-    'entity' => 'INDONESIA',
     'minorUnit' => 2,
     'numericCode' => 360,
   ),
@@ -611,7 +521,6 @@
   array (
     'alphabeticCode' => 'XDR',
     'currency' => 'SDR (Special Drawing Right)',
-    'entity' => 'INTERNATIONAL MONETARY FUND (IMF) ',
     'minorUnit' => 0,
     'numericCode' => 960,
   ),
@@ -619,7 +528,6 @@
   array (
     'alphabeticCode' => 'IRR',
     'currency' => 'Iranian Rial',
-    'entity' => 'IRAN (ISLAMIC REPUBLIC OF)',
     'minorUnit' => 2,
     'numericCode' => 364,
   ),
@@ -627,7 +535,6 @@
   array (
     'alphabeticCode' => 'IQD',
     'currency' => 'Iraqi Dinar',
-    'entity' => 'IRAQ',
     'minorUnit' => 3,
     'numericCode' => 368,
   ),
@@ -635,7 +542,6 @@
   array (
     'alphabeticCode' => 'ILS',
     'currency' => 'New Israeli Sheqel',
-    'entity' => 'ISRAEL',
     'minorUnit' => 2,
     'numericCode' => 376,
   ),
@@ -643,7 +549,6 @@
   array (
     'alphabeticCode' => 'JMD',
     'currency' => 'Jamaican Dollar',
-    'entity' => 'JAMAICA',
     'minorUnit' => 2,
     'numericCode' => 388,
   ),
@@ -651,7 +556,6 @@
   array (
     'alphabeticCode' => 'JPY',
     'currency' => 'Yen',
-    'entity' => 'JAPAN',
     'minorUnit' => 0,
     'numericCode' => 392,
   ),
@@ -659,7 +563,6 @@
   array (
     'alphabeticCode' => 'JOD',
     'currency' => 'Jordanian Dinar',
-    'entity' => 'JORDAN',
     'minorUnit' => 3,
     'numericCode' => 400,
   ),
@@ -667,7 +570,6 @@
   array (
     'alphabeticCode' => 'KZT',
     'currency' => 'Tenge',
-    'entity' => 'KAZAKHSTAN',
     'minorUnit' => 2,
     'numericCode' => 398,
   ),
@@ -675,7 +577,6 @@
   array (
     'alphabeticCode' => 'KES',
     'currency' => 'Kenyan Shilling',
-    'entity' => 'KENYA',
     'minorUnit' => 2,
     'numericCode' => 404,
   ),
@@ -683,7 +584,6 @@
   array (
     'alphabeticCode' => 'KPW',
     'currency' => 'North Korean Won',
-    'entity' => 'KOREA (THE DEMOCRATIC PEOPLE’S REPUBLIC OF)',
     'minorUnit' => 2,
     'numericCode' => 408,
   ),
@@ -691,7 +591,6 @@
   array (
     'alphabeticCode' => 'KRW',
     'currency' => 'Won',
-    'entity' => 'KOREA (THE REPUBLIC OF)',
     'minorUnit' => 0,
     'numericCode' => 410,
   ),
@@ -699,7 +598,6 @@
   array (
     'alphabeticCode' => 'KWD',
     'currency' => 'Kuwaiti Dinar',
-    'entity' => 'KUWAIT',
     'minorUnit' => 3,
     'numericCode' => 414,
   ),
@@ -707,7 +605,6 @@
   array (
     'alphabeticCode' => 'KGS',
     'currency' => 'Som',
-    'entity' => 'KYRGYZSTAN',
     'minorUnit' => 2,
     'numericCode' => 417,
   ),
@@ -715,7 +612,6 @@
   array (
     'alphabeticCode' => 'LAK',
     'currency' => 'Kip',
-    'entity' => 'LAO PEOPLE’S DEMOCRATIC REPUBLIC (THE)',
     'minorUnit' => 2,
     'numericCode' => 418,
   ),
@@ -723,7 +619,6 @@
   array (
     'alphabeticCode' => 'LBP',
     'currency' => 'Lebanese Pound',
-    'entity' => 'LEBANON',
     'minorUnit' => 2,
     'numericCode' => 422,
   ),
@@ -731,7 +626,6 @@
   array (
     'alphabeticCode' => 'LSL',
     'currency' => 'Loti',
-    'entity' => 'LESOTHO',
     'minorUnit' => 2,
     'numericCode' => 426,
   ),
@@ -739,7 +633,6 @@
   array (
     'alphabeticCode' => 'ZAR',
     'currency' => 'Rand',
-    'entity' => 'SOUTH AFRICA',
     'minorUnit' => 2,
     'numericCode' => 710,
   ),
@@ -747,7 +640,6 @@
   array (
     'alphabeticCode' => 'LRD',
     'currency' => 'Liberian Dollar',
-    'entity' => 'LIBERIA',
     'minorUnit' => 2,
     'numericCode' => 430,
   ),
@@ -755,7 +647,6 @@
   array (
     'alphabeticCode' => 'LYD',
     'currency' => 'Libyan Dinar',
-    'entity' => 'LIBYA',
     'minorUnit' => 3,
     'numericCode' => 434,
   ),
@@ -763,7 +654,6 @@
   array (
     'alphabeticCode' => 'CHF',
     'currency' => 'Swiss Franc',
-    'entity' => 'SWITZERLAND',
     'minorUnit' => 2,
     'numericCode' => 756,
   ),
@@ -771,7 +661,6 @@
   array (
     'alphabeticCode' => 'MOP',
     'currency' => 'Pataca',
-    'entity' => 'MACAO',
     'minorUnit' => 2,
     'numericCode' => 446,
   ),
@@ -779,7 +668,6 @@
   array (
     'alphabeticCode' => 'MKD',
     'currency' => 'Denar',
-    'entity' => 'MACEDONIA (THE FORMER YUGOSLAV REPUBLIC OF)',
     'minorUnit' => 2,
     'numericCode' => 807,
   ),
@@ -787,7 +675,6 @@
   array (
     'alphabeticCode' => 'MGA',
     'currency' => 'Malagasy Ariary',
-    'entity' => 'MADAGASCAR',
     'minorUnit' => 2,
     'numericCode' => 969,
   ),
@@ -795,7 +682,6 @@
   array (
     'alphabeticCode' => 'MWK',
     'currency' => 'Malawi Kwacha',
-    'entity' => 'MALAWI',
     'minorUnit' => 2,
     'numericCode' => 454,
   ),
@@ -803,7 +689,6 @@
   array (
     'alphabeticCode' => 'MYR',
     'currency' => 'Malaysian Ringgit',
-    'entity' => 'MALAYSIA',
     'minorUnit' => 2,
     'numericCode' => 458,
   ),
@@ -811,7 +696,6 @@
   array (
     'alphabeticCode' => 'MVR',
     'currency' => 'Rufiyaa',
-    'entity' => 'MALDIVES',
     'minorUnit' => 2,
     'numericCode' => 462,
   ),
@@ -819,7 +703,6 @@
   array (
     'alphabeticCode' => 'MRO',
     'currency' => 'Ouguiya',
-    'entity' => 'MAURITANIA',
     'minorUnit' => 2,
     'numericCode' => 478,
   ),
@@ -827,7 +710,6 @@
   array (
     'alphabeticCode' => 'MUR',
     'currency' => 'Mauritius Rupee',
-    'entity' => 'MAURITIUS',
     'minorUnit' => 2,
     'numericCode' => 480,
   ),
@@ -835,7 +717,6 @@
   array (
     'alphabeticCode' => 'XUA',
     'currency' => 'ADB Unit of Account',
-    'entity' => 'MEMBER COUNTRIES OF THE AFRICAN DEVELOPMENT BANK GROUP',
     'minorUnit' => 0,
     'numericCode' => 965,
   ),
@@ -843,7 +724,6 @@
   array (
     'alphabeticCode' => 'MXN',
     'currency' => 'Mexican Peso',
-    'entity' => 'MEXICO',
     'minorUnit' => 2,
     'numericCode' => 484,
   ),
@@ -851,7 +731,6 @@
   array (
     'alphabeticCode' => 'MXV',
     'currency' => 'Mexican Unidad de Inversion (UDI)',
-    'entity' => 'MEXICO',
     'minorUnit' => 2,
     'numericCode' => 979,
   ),
@@ -859,7 +738,6 @@
   array (
     'alphabeticCode' => 'MDL',
     'currency' => 'Moldovan Leu',
-    'entity' => 'MOLDOVA (THE REPUBLIC OF)',
     'minorUnit' => 2,
     'numericCode' => 498,
   ),
@@ -867,7 +745,6 @@
   array (
     'alphabeticCode' => 'MNT',
     'currency' => 'Tugrik',
-    'entity' => 'MONGOLIA',
     'minorUnit' => 2,
     'numericCode' => 496,
   ),
@@ -875,7 +752,6 @@
   array (
     'alphabeticCode' => 'MAD',
     'currency' => 'Moroccan Dirham',
-    'entity' => 'WESTERN SAHARA',
     'minorUnit' => 2,
     'numericCode' => 504,
   ),
@@ -883,7 +759,6 @@
   array (
     'alphabeticCode' => 'MZN',
     'currency' => 'Mozambique Metical',
-    'entity' => 'MOZAMBIQUE',
     'minorUnit' => 2,
     'numericCode' => 943,
   ),
@@ -891,7 +766,6 @@
   array (
     'alphabeticCode' => 'MMK',
     'currency' => 'Kyat',
-    'entity' => 'MYANMAR',
     'minorUnit' => 2,
     'numericCode' => 104,
   ),
@@ -899,7 +773,6 @@
   array (
     'alphabeticCode' => 'NAD',
     'currency' => 'Namibia Dollar',
-    'entity' => 'NAMIBIA',
     'minorUnit' => 2,
     'numericCode' => 516,
   ),
@@ -907,7 +780,6 @@
   array (
     'alphabeticCode' => 'NPR',
     'currency' => 'Nepalese Rupee',
-    'entity' => 'NEPAL',
     'minorUnit' => 2,
     'numericCode' => 524,
   ),
@@ -915,7 +787,6 @@
   array (
     'alphabeticCode' => 'NIO',
     'currency' => 'Cordoba Oro',
-    'entity' => 'NICARAGUA',
     'minorUnit' => 2,
     'numericCode' => 558,
   ),
@@ -923,7 +794,6 @@
   array (
     'alphabeticCode' => 'NGN',
     'currency' => 'Naira',
-    'entity' => 'NIGERIA',
     'minorUnit' => 2,
     'numericCode' => 566,
   ),
@@ -931,7 +801,6 @@
   array (
     'alphabeticCode' => 'OMR',
     'currency' => 'Rial Omani',
-    'entity' => 'OMAN',
     'minorUnit' => 3,
     'numericCode' => 512,
   ),
@@ -939,7 +808,6 @@
   array (
     'alphabeticCode' => 'PKR',
     'currency' => 'Pakistan Rupee',
-    'entity' => 'PAKISTAN',
     'minorUnit' => 2,
     'numericCode' => 586,
   ),
@@ -947,7 +815,6 @@
   array (
     'alphabeticCode' => 'PAB',
     'currency' => 'Balboa',
-    'entity' => 'PANAMA',
     'minorUnit' => 2,
     'numericCode' => 590,
   ),
@@ -955,7 +822,6 @@
   array (
     'alphabeticCode' => 'PGK',
     'currency' => 'Kina',
-    'entity' => 'PAPUA NEW GUINEA',
     'minorUnit' => 2,
     'numericCode' => 598,
   ),
@@ -963,7 +829,6 @@
   array (
     'alphabeticCode' => 'PYG',
     'currency' => 'Guarani',
-    'entity' => 'PARAGUAY',
     'minorUnit' => 0,
     'numericCode' => 600,
   ),
@@ -971,7 +836,6 @@
   array (
     'alphabeticCode' => 'PEN',
     'currency' => 'Sol',
-    'entity' => 'PERU',
     'minorUnit' => 2,
     'numericCode' => 604,
   ),
@@ -979,7 +843,6 @@
   array (
     'alphabeticCode' => 'PHP',
     'currency' => 'Philippine Peso',
-    'entity' => 'PHILIPPINES (THE)',
     'minorUnit' => 2,
     'numericCode' => 608,
   ),
@@ -987,7 +850,6 @@
   array (
     'alphabeticCode' => 'PLN',
     'currency' => 'Zloty',
-    'entity' => 'POLAND',
     'minorUnit' => 2,
     'numericCode' => 985,
   ),
@@ -995,7 +857,6 @@
   array (
     'alphabeticCode' => 'QAR',
     'currency' => 'Qatari Rial',
-    'entity' => 'QATAR',
     'minorUnit' => 2,
     'numericCode' => 634,
   ),
@@ -1003,7 +864,6 @@
   array (
     'alphabeticCode' => 'RON',
     'currency' => 'Romanian Leu',
-    'entity' => 'ROMANIA',
     'minorUnit' => 2,
     'numericCode' => 946,
   ),
@@ -1011,7 +871,6 @@
   array (
     'alphabeticCode' => 'RUB',
     'currency' => 'Russian Ruble',
-    'entity' => 'RUSSIAN FEDERATION (THE)',
     'minorUnit' => 2,
     'numericCode' => 643,
   ),
@@ -1019,7 +878,6 @@
   array (
     'alphabeticCode' => 'RWF',
     'currency' => 'Rwanda Franc',
-    'entity' => 'RWANDA',
     'minorUnit' => 0,
     'numericCode' => 646,
   ),
@@ -1027,7 +885,6 @@
   array (
     'alphabeticCode' => 'SHP',
     'currency' => 'Saint Helena Pound',
-    'entity' => 'SAINT HELENA, ASCENSION AND TRISTAN DA CUNHA',
     'minorUnit' => 2,
     'numericCode' => 654,
   ),
@@ -1035,7 +892,6 @@
   array (
     'alphabeticCode' => 'WST',
     'currency' => 'Tala',
-    'entity' => 'SAMOA',
     'minorUnit' => 2,
     'numericCode' => 882,
   ),
@@ -1043,7 +899,6 @@
   array (
     'alphabeticCode' => 'STD',
     'currency' => 'Dobra',
-    'entity' => 'SAO TOME AND PRINCIPE',
     'minorUnit' => 2,
     'numericCode' => 678,
   ),
@@ -1051,7 +906,6 @@
   array (
     'alphabeticCode' => 'SAR',
     'currency' => 'Saudi Riyal',
-    'entity' => 'SAUDI ARABIA',
     'minorUnit' => 2,
     'numericCode' => 682,
   ),
@@ -1059,7 +913,6 @@
   array (
     'alphabeticCode' => 'RSD',
     'currency' => 'Serbian Dinar',
-    'entity' => 'SERBIA',
     'minorUnit' => 2,
     'numericCode' => 941,
   ),
@@ -1067,7 +920,6 @@
   array (
     'alphabeticCode' => 'SCR',
     'currency' => 'Seychelles Rupee',
-    'entity' => 'SEYCHELLES',
     'minorUnit' => 2,
     'numericCode' => 690,
   ),
@@ -1075,7 +927,6 @@
   array (
     'alphabeticCode' => 'SLL',
     'currency' => 'Leone',
-    'entity' => 'SIERRA LEONE',
     'minorUnit' => 2,
     'numericCode' => 694,
   ),
@@ -1083,7 +934,6 @@
   array (
     'alphabeticCode' => 'SGD',
     'currency' => 'Singapore Dollar',
-    'entity' => 'SINGAPORE',
     'minorUnit' => 2,
     'numericCode' => 702,
   ),
@@ -1091,7 +941,6 @@
   array (
     'alphabeticCode' => 'XSU',
     'currency' => 'Sucre',
-    'entity' => 'SISTEMA UNITARIO DE COMPENSACION REGIONAL DE PAGOS "SUCRE"',
     'minorUnit' => 0,
     'numericCode' => 994,
   ),
@@ -1099,7 +948,6 @@
   array (
     'alphabeticCode' => 'SBD',
     'currency' => 'Solomon Islands Dollar',
-    'entity' => 'SOLOMON ISLANDS',
     'minorUnit' => 2,
     'numericCode' => 90,
   ),
@@ -1107,7 +955,6 @@
   array (
     'alphabeticCode' => 'SOS',
     'currency' => 'Somali Shilling',
-    'entity' => 'SOMALIA',
     'minorUnit' => 2,
     'numericCode' => 706,
   ),
@@ -1115,7 +962,6 @@
   array (
     'alphabeticCode' => 'SSP',
     'currency' => 'South Sudanese Pound',
-    'entity' => 'SOUTH SUDAN',
     'minorUnit' => 2,
     'numericCode' => 728,
   ),
@@ -1123,7 +969,6 @@
   array (
     'alphabeticCode' => 'LKR',
     'currency' => 'Sri Lanka Rupee',
-    'entity' => 'SRI LANKA',
     'minorUnit' => 2,
     'numericCode' => 144,
   ),
@@ -1131,7 +976,6 @@
   array (
     'alphabeticCode' => 'SDG',
     'currency' => 'Sudanese Pound',
-    'entity' => 'SUDAN (THE)',
     'minorUnit' => 2,
     'numericCode' => 938,
   ),
@@ -1139,7 +983,6 @@
   array (
     'alphabeticCode' => 'SRD',
     'currency' => 'Surinam Dollar',
-    'entity' => 'SURINAME',
     'minorUnit' => 2,
     'numericCode' => 968,
   ),
@@ -1147,7 +990,6 @@
   array (
     'alphabeticCode' => 'SZL',
     'currency' => 'Lilangeni',
-    'entity' => 'SWAZILAND',
     'minorUnit' => 2,
     'numericCode' => 748,
   ),
@@ -1155,7 +997,6 @@
   array (
     'alphabeticCode' => 'SEK',
     'currency' => 'Swedish Krona',
-    'entity' => 'SWEDEN',
     'minorUnit' => 2,
     'numericCode' => 752,
   ),
@@ -1163,7 +1004,6 @@
   array (
     'alphabeticCode' => 'CHE',
     'currency' => 'WIR Euro',
-    'entity' => 'SWITZERLAND',
     'minorUnit' => 2,
     'numericCode' => 947,
   ),
@@ -1171,7 +1011,6 @@
   array (
     'alphabeticCode' => 'CHW',
     'currency' => 'WIR Franc',
-    'entity' => 'SWITZERLAND',
     'minorUnit' => 2,
     'numericCode' => 948,
   ),
@@ -1179,7 +1018,6 @@
   array (
     'alphabeticCode' => 'SYP',
     'currency' => 'Syrian Pound',
-    'entity' => 'SYRIAN ARAB REPUBLIC',
     'minorUnit' => 2,
     'numericCode' => 760,
   ),
@@ -1187,7 +1025,6 @@
   array (
     'alphabeticCode' => 'TWD',
     'currency' => 'New Taiwan Dollar',
-    'entity' => 'TAIWAN (PROVINCE OF CHINA)',
     'minorUnit' => 2,
     'numericCode' => 901,
   ),
@@ -1195,7 +1032,6 @@
   array (
     'alphabeticCode' => 'TJS',
     'currency' => 'Somoni',
-    'entity' => 'TAJIKISTAN',
     'minorUnit' => 2,
     'numericCode' => 972,
   ),
@@ -1203,7 +1039,6 @@
   array (
     'alphabeticCode' => 'TZS',
     'currency' => 'Tanzanian Shilling',
-    'entity' => 'TANZANIA, UNITED REPUBLIC OF',
     'minorUnit' => 2,
     'numericCode' => 834,
   ),
@@ -1211,7 +1046,6 @@
   array (
     'alphabeticCode' => 'THB',
     'currency' => 'Baht',
-    'entity' => 'THAILAND',
     'minorUnit' => 2,
     'numericCode' => 764,
   ),
@@ -1219,7 +1053,6 @@
   array (
     'alphabeticCode' => 'TOP',
     'currency' => 'Pa’anga',
-    'entity' => 'TONGA',
     'minorUnit' => 2,
     'numericCode' => 776,
   ),
@@ -1227,7 +1060,6 @@
   array (
     'alphabeticCode' => 'TTD',
     'currency' => 'Trinidad and Tobago Dollar',
-    'entity' => 'TRINIDAD AND TOBAGO',
     'minorUnit' => 2,
     'numericCode' => 780,
   ),
@@ -1235,7 +1067,6 @@
   array (
     'alphabeticCode' => 'TND',
     'currency' => 'Tunisian Dinar',
-    'entity' => 'TUNISIA',
     'minorUnit' => 3,
     'numericCode' => 788,
   ),
@@ -1243,7 +1074,6 @@
   array (
     'alphabeticCode' => 'TRY',
     'currency' => 'Turkish Lira',
-    'entity' => 'TURKEY',
     'minorUnit' => 2,
     'numericCode' => 949,
   ),
@@ -1251,7 +1081,6 @@
   array (
     'alphabeticCode' => 'TMT',
     'currency' => 'Turkmenistan New Manat',
-    'entity' => 'TURKMENISTAN',
     'minorUnit' => 2,
     'numericCode' => 934,
   ),
@@ -1259,7 +1088,6 @@
   array (
     'alphabeticCode' => 'UGX',
     'currency' => 'Uganda Shilling',
-    'entity' => 'UGANDA',
     'minorUnit' => 0,
     'numericCode' => 800,
   ),
@@ -1267,7 +1095,6 @@
   array (
     'alphabeticCode' => 'UAH',
     'currency' => 'Hryvnia',
-    'entity' => 'UKRAINE',
     'minorUnit' => 2,
     'numericCode' => 980,
   ),
@@ -1275,7 +1102,6 @@
   array (
     'alphabeticCode' => 'AED',
     'currency' => 'UAE Dirham',
-    'entity' => 'UNITED ARAB EMIRATES (THE)',
     'minorUnit' => 2,
     'numericCode' => 784,
   ),
@@ -1283,7 +1109,6 @@
   array (
     'alphabeticCode' => 'USN',
     'currency' => 'US Dollar (Next day)',
-    'entity' => 'UNITED STATES OF AMERICA (THE)',
     'minorUnit' => 2,
     'numericCode' => 997,
   ),
@@ -1291,7 +1116,6 @@
   array (
     'alphabeticCode' => 'UYU',
     'currency' => 'Peso Uruguayo',
-    'entity' => 'URUGUAY',
     'minorUnit' => 2,
     'numericCode' => 858,
   ),
@@ -1299,7 +1123,6 @@
   array (
     'alphabeticCode' => 'UYI',
     'currency' => 'Uruguay Peso en Unidades Indexadas (URUIURUI)',
-    'entity' => 'URUGUAY',
     'minorUnit' => 0,
     'numericCode' => 940,
   ),
@@ -1307,7 +1130,6 @@
   array (
     'alphabeticCode' => 'UZS',
     'currency' => 'Uzbekistan Sum',
-    'entity' => 'UZBEKISTAN',
     'minorUnit' => 2,
     'numericCode' => 860,
   ),
@@ -1315,7 +1137,6 @@
   array (
     'alphabeticCode' => 'VUV',
     'currency' => 'Vatu',
-    'entity' => 'VANUATU',
     'minorUnit' => 0,
     'numericCode' => 548,
   ),
@@ -1323,7 +1144,6 @@
   array (
     'alphabeticCode' => 'VEF',
     'currency' => 'Bolívar',
-    'entity' => 'VENEZUELA (BOLIVARIAN REPUBLIC OF)',
     'minorUnit' => 2,
     'numericCode' => 937,
   ),
@@ -1331,7 +1151,6 @@
   array (
     'alphabeticCode' => 'VND',
     'currency' => 'Dong',
-    'entity' => 'VIET NAM',
     'minorUnit' => 0,
     'numericCode' => 704,
   ),
@@ -1339,7 +1158,6 @@
   array (
     'alphabeticCode' => 'YER',
     'currency' => 'Yemeni Rial',
-    'entity' => 'YEMEN',
     'minorUnit' => 2,
     'numericCode' => 886,
   ),
@@ -1347,7 +1165,6 @@
   array (
     'alphabeticCode' => 'ZMW',
     'currency' => 'Zambian Kwacha',
-    'entity' => 'ZAMBIA',
     'minorUnit' => 2,
     'numericCode' => 967,
   ),
@@ -1355,7 +1172,6 @@
   array (
     'alphabeticCode' => 'ZWL',
     'currency' => 'Zimbabwe Dollar',
-    'entity' => 'ZIMBABWE',
     'minorUnit' => 2,
     'numericCode' => 932,
   ),
@@ -1363,7 +1179,6 @@
   array (
     'alphabeticCode' => 'XBA',
     'currency' => 'Bond Markets Unit European Composite Unit (EURCO)',
-    'entity' => 'ZZ01_Bond Markets Unit European_EURCO',
     'minorUnit' => 0,
     'numericCode' => 955,
   ),
@@ -1371,7 +1186,6 @@
   array (
     'alphabeticCode' => 'XBB',
     'currency' => 'Bond Markets Unit European Monetary Unit (E.M.U.-6)',
-    'entity' => 'ZZ02_Bond Markets Unit European_EMU-6',
     'minorUnit' => 0,
     'numericCode' => 956,
   ),
@@ -1379,7 +1193,6 @@
   array (
     'alphabeticCode' => 'XBC',
     'currency' => 'Bond Markets Unit European Unit of Account 9 (E.U.A.-9)',
-    'entity' => 'ZZ03_Bond Markets Unit European_EUA-9',
     'minorUnit' => 0,
     'numericCode' => 957,
   ),
@@ -1387,7 +1200,6 @@
   array (
     'alphabeticCode' => 'XBD',
     'currency' => 'Bond Markets Unit European Unit of Account 17 (E.U.A.-17)',
-    'entity' => 'ZZ04_Bond Markets Unit European_EUA-17',
     'minorUnit' => 0,
     'numericCode' => 958,
   ),
@@ -1395,7 +1207,6 @@
   array (
     'alphabeticCode' => 'XTS',
     'currency' => 'Codes specifically reserved for testing purposes',
-    'entity' => 'ZZ06_Testing_Code',
     'minorUnit' => 0,
     'numericCode' => 963,
   ),
@@ -1403,7 +1214,6 @@
   array (
     'alphabeticCode' => 'XXX',
     'currency' => 'The codes assigned for transactions where no currency is involved',
-    'entity' => 'ZZ07_No_Currency',
     'minorUnit' => 0,
     'numericCode' => 999,
   ),
@@ -1411,7 +1221,6 @@
   array (
     'alphabeticCode' => 'XAU',
     'currency' => 'Gold',
-    'entity' => 'ZZ08_Gold',
     'minorUnit' => 0,
     'numericCode' => 959,
   ),
@@ -1419,7 +1228,6 @@
   array (
     'alphabeticCode' => 'XPD',
     'currency' => 'Palladium',
-    'entity' => 'ZZ09_Palladium',
     'minorUnit' => 0,
     'numericCode' => 964,
   ),
@@ -1427,7 +1235,6 @@
   array (
     'alphabeticCode' => 'XPT',
     'currency' => 'Platinum',
-    'entity' => 'ZZ10_Platinum',
     'minorUnit' => 0,
     'numericCode' => 962,
   ),
@@ -1435,7 +1242,6 @@
   array (
     'alphabeticCode' => 'XAG',
     'currency' => 'Silver',
-    'entity' => 'ZZ11_Silver',
     'minorUnit' => 0,
     'numericCode' => 961,
   ),

--- a/tests/Currencies/ISOCurrenciesTest.php
+++ b/tests/Currencies/ISOCurrenciesTest.php
@@ -54,6 +54,16 @@ final class ISOCurrenciesTest extends \PHPUnit_Framework_TestCase
         $this->assertContainsOnlyInstancesOf(Currency::class, $iterator);
     }
 
+    /**
+     * @test
+     */
+    public function it_does_not_have_blank_currency()
+    {
+        $currencies = new ISOCurrencies();
+
+        $this->assertFalse($currencies->contains(new Currency('')));
+    }
+
     public function currencyCodeExamples()
     {
         $currencies = require __DIR__.'/../../resources/currency.php';


### PR DESCRIPTION
Ready to merge.

Currently, due to an issue in the `moneyphp/iso-currencies` repository, a 'blank' currency is present in the ISOCurrencies repository.

There is a fix for that issue pending https://github.com/moneyphp/iso-currencies/pull/4.

Initial tests have been added for proof of claim and regression testing. Once the issue in iso-currencies has been resolved, this PR will be updated.