### PR TITLE
Enable $money->divide and $money->multiply to accept Money instances as operands.

### DIFF
--- a/src/Money.php
+++ b/src/Money.php
@@ -259,9 +259,9 @@ final class Money implements \JsonSerializable
      */
     private function assertOperand($operand)
     {
-        if (!is_numeric($operand)) {
+        if (!is_numeric($operand) && !$operand instanceof self) {
             throw new \InvalidArgumentException(sprintf(
-                'Operand should be a numeric value, "%s" given.',
+                'Operand should be a numeric value or Money instance, "%s" given.',
                 is_object($operand) ? get_class($operand) : gettype($operand)
             ));
         }
@@ -296,7 +296,7 @@ final class Money implements \JsonSerializable
      * Returns a new Money object that represents
      * the multiplied value by the given factor.
      *
-     * @param float|int|string $multiplier
+     * @param float|int|string|self $multiplier
      * @param int              $roundingMode
      *
      * @return Money
@@ -305,7 +305,13 @@ final class Money implements \JsonSerializable
     {
         $this->assertOperand($multiplier);
         $this->assertRoundingMode($roundingMode);
-
+		
+		if ($multiplier instanceof self) {
+			$this->assertSameCurrency($multiplier);
+			
+			$multiplier = $multiplier->getAmount();
+		}
+		
         if (is_float($multiplier)) {
             $multiplier = (string) Number::fromFloat($multiplier);
         }
@@ -319,7 +325,7 @@ final class Money implements \JsonSerializable
      * Returns a new Money object that represents
      * the divided value by the given factor.
      *
-     * @param float|int|string $divisor
+     * @param float|int|string|self $divisor
      * @param int              $roundingMode
      *
      * @return Money
@@ -329,6 +335,13 @@ final class Money implements \JsonSerializable
         $this->assertOperand($divisor);
         $this->assertRoundingMode($roundingMode);
 
+		
+		if ($divisor instanceof self) {
+			$this->assertSameCurrency($divisor);
+			
+			$divisor = $divisor->getAmount();
+		}
+		
         if (is_float($divisor)) {
             $divisor = (string) Number::fromFloat($divisor);
         }

--- a/src/Money.php
+++ b/src/Money.php
@@ -333,14 +333,12 @@ final class Money implements \JsonSerializable
         $this->assertRoundingMode($roundingMode);
 
 
-        if ($divisor instanceof self) {
+        if (is_float($divisor)) {
+            $divisor = (string) Number::fromFloat($divisor);
+        }else if ($divisor instanceof self) {
             $this->assertSameCurrency($divisor);
 
             $divisor = $divisor->getAmount();
-        }
-
-        if (is_float($divisor)) {
-            $divisor = (string) Number::fromFloat($divisor);
         }
 
         if ($this->getCalculator()->compare((string) $divisor, '0') === 0) {

--- a/src/Money.php
+++ b/src/Money.php
@@ -335,7 +335,7 @@ final class Money implements \JsonSerializable
 
         if (is_float($divisor)) {
             $divisor = (string) Number::fromFloat($divisor);
-        }else if ($divisor instanceof self) {
+        } else if ($divisor instanceof self) {
             $this->assertSameCurrency($divisor);
 
             $divisor = $divisor->getAmount();

--- a/src/Money.php
+++ b/src/Money.php
@@ -259,7 +259,7 @@ final class Money implements \JsonSerializable
      */
     private function assertOperand($operand)
     {
-        if (!is_numeric($operand) && !$operand instanceof self) {
+        if (!is_numeric($operand) && !($operand instanceof self)) {
             throw new \InvalidArgumentException(sprintf(
                 'Operand should be a numeric value or Money instance, "%s" given.',
                 is_object($operand) ? get_class($operand) : gettype($operand)
@@ -305,17 +305,14 @@ final class Money implements \JsonSerializable
     {
         $this->assertOperand($multiplier);
         $this->assertRoundingMode($roundingMode);
-		
-		if ($multiplier instanceof self) {
-			$this->assertSameCurrency($multiplier);
-			
-			$multiplier = $multiplier->getAmount();
-		}
-		
+
         if (is_float($multiplier)) {
             $multiplier = (string) Number::fromFloat($multiplier);
+        } else if ($multiplier instanceof self) {
+            $this->assertSameCurrency($multiplier);
+            
+            $multiplier = $multiplier->getAmount();
         }
-
         $product = $this->round($this->getCalculator()->multiply($this->amount, $multiplier), $roundingMode);
 
         return $this->newInstance($product);
@@ -335,13 +332,13 @@ final class Money implements \JsonSerializable
         $this->assertOperand($divisor);
         $this->assertRoundingMode($roundingMode);
 
-		
-		if ($divisor instanceof self) {
-			$this->assertSameCurrency($divisor);
-			
-			$divisor = $divisor->getAmount();
-		}
-		
+
+        if ($divisor instanceof self) {
+            $this->assertSameCurrency($divisor);
+
+            $divisor = $divisor->getAmount();
+        }
+
         if (is_float($divisor)) {
             $divisor = (string) Number::fromFloat($divisor);
         }

--- a/tests/MoneyTest.php
+++ b/tests/MoneyTest.php
@@ -296,32 +296,161 @@ final class MoneyTest extends \PHPUnit_Framework_TestCase
             ['-1', 1],
         ];
     }
-	
-	
-	
-	
+
+    public function multiplyOtherExamples()
+    {
+        return [
+            [0, 1, 0],
+            [0, 7, 0],
+            [5, 36, 180],
+            [8, 2, 16],
+            [12, 7, 84],
+            [15, 11, 165],
+            [16, 21, 336],
+            [18, 31, 558],
+            [22, 139, 3058],
+            [24, 22, 528],
+            [26, 1, 26],
+            [29, 22, 638],
+            [29, 19, 551],
+            [31, 106, 3286],
+            [33, 87, 2871],
+            [37, 116, 4292],
+            [40, 79, 3160],
+            [41, 3, 123],
+            [41, 30, 1230],
+            [42, 111, 4662],
+            [43, 37, 1591],
+            [48, 58, 2784],
+            [48, 13, 624],
+            [57, 104, 5928],
+            [58, 43, 2494],
+            [68, 6, 408],
+            [68, 29, 1972],
+            [78, 41, 3198],
+            [81, 138, 11178],
+            [87, 45, 3915],
+            [106, 71, 7526],
+            [109, 45, 4905],
+            [122, 66, 8052],
+            [129, 47, 6063],
+            [131, 198, 25938],
+            [142, 145, 20590],
+            [158, 59, 9322],
+            [159, 159, 25281],
+            [191, 196, 37436],
+        ];
+    }
+
+    public function divideOtherExamples()
+    {
+        return [
+            [0, 1, Money::ROUND_UP, 0],
+            [0, 1, Money::ROUND_DOWN, 0],
+            [1, 43, Money::ROUND_DOWN, 0],
+            [14, 9, Money::ROUND_UP, 2],
+            [17, 2, Money::ROUND_DOWN, 8],
+            [28, 8, Money::ROUND_DOWN, 3],
+            [40, 2, Money::ROUND_UP, 20],
+            [136, 6, Money::ROUND_UP, 23],
+            [160, 9, Money::ROUND_UP, 18],
+            [175, 8, Money::ROUND_DOWN, 21],
+            [180, 19, Money::ROUND_UP, 10],
+            [333, 3, Money::ROUND_UP, 111],
+            [398, 58, Money::ROUND_DOWN, 6],
+            [407, 5, Money::ROUND_DOWN, 81],
+            [732, 3, Money::ROUND_DOWN, 244],
+            [798, 55, Money::ROUND_DOWN, 14],
+            [840, 24, Money::ROUND_UP, 35],
+            [898, 5, Money::ROUND_DOWN, 179],
+            [943, 26, Money::ROUND_UP, 37],
+            [947, 32, Money::ROUND_DOWN, 29],
+            [1173, 5, Money::ROUND_UP, 235],
+            [1298, 3, Money::ROUND_DOWN, 432],
+            [1379, 17, Money::ROUND_UP, 82],
+            [1389, 16, Money::ROUND_UP, 87],
+            [1509, 75, Money::ROUND_DOWN, 20],
+            [1793, 63, Money::ROUND_UP, 29],
+            [1798, 103, Money::ROUND_DOWN, 17],
+            [2296, 41, Money::ROUND_DOWN, 56],
+            [2734, 73, Money::ROUND_UP, 38],
+            [3168, 53, Money::ROUND_UP, 60],
+            [3329, 55, Money::ROUND_UP, 61],
+            [3359, 40, Money::ROUND_DOWN, 83],
+            [3603, 14, Money::ROUND_DOWN, 257],
+            [3708, 7, Money::ROUND_UP, 530],
+            [3901, 10, Money::ROUND_UP, 391],
+            [3916, 74, Money::ROUND_DOWN, 52],
+            [4011, 181, Money::ROUND_DOWN, 22],
+            [4047, 15, Money::ROUND_DOWN, 269],
+            [4082, 42, Money::ROUND_UP, 98],
+            [4307, 56, Money::ROUND_DOWN, 76],
+            [4754, 17, Money::ROUND_UP, 280],
+            [4842, 59, Money::ROUND_DOWN, 82],
+            [5848, 83, Money::ROUND_UP, 71],
+            [6149, 15, Money::ROUND_DOWN, 409],
+            [6588, 17, Money::ROUND_DOWN, 387],
+            [6696, 77, Money::ROUND_DOWN, 86],
+            [7154, 95, Money::ROUND_UP, 76],
+            [7391, 49, Money::ROUND_DOWN, 150],
+            [7580, 155, Money::ROUND_UP, 49],
+            [8141, 60, Money::ROUND_UP, 136],
+            [8451, 53, Money::ROUND_UP, 160],
+            [9361, 50, Money::ROUND_DOWN, 187],
+            [9520, 81, Money::ROUND_DOWN, 117],
+            [12777, 140, Money::ROUND_UP, 92],
+            [13135, 10, Money::ROUND_UP, 1314],
+            [13289, 47, Money::ROUND_DOWN, 282],
+            [14936, 102, Money::ROUND_UP, 147],
+            [15185, 186, Money::ROUND_DOWN, 81],
+            [15612, 126, Money::ROUND_UP, 124],
+            [15700, 119, Money::ROUND_UP, 132],
+            [17102, 121, Money::ROUND_DOWN, 141],
+            [17258, 54, Money::ROUND_DOWN, 319],
+            [17562, 158, Money::ROUND_DOWN, 111],
+            [18252, 57, Money::ROUND_UP, 321],
+            [18941, 39, Money::ROUND_UP, 486],
+            [19662, 80, Money::ROUND_DOWN, 245],
+            [20048, 141, Money::ROUND_UP, 143],
+            [21341, 16, Money::ROUND_DOWN, 1333],
+            [21564, 131, Money::ROUND_UP, 165],
+            [22346, 117, Money::ROUND_UP, 191],
+            [23720, 126, Money::ROUND_UP, 189],
+            [26536, 210, Money::ROUND_DOWN, 126],
+            [27823, 182, Money::ROUND_UP, 153],
+            [28727, 14, Money::ROUND_DOWN, 2051],
+            [29279, 17, Money::ROUND_UP, 1723],
+            [29856, 207, Money::ROUND_UP, 145],
+            [29893, 170, Money::ROUND_DOWN, 175],
+            [34119, 19, Money::ROUND_UP, 1796],
+            [34586, 63, Money::ROUND_DOWN, 548],
+            [34682, 52, Money::ROUND_DOWN, 666],
+        ];
+    }
+    
     /**
-     * @dataProvider roundExamples
+     * @dataProvider multiplyOtherExamples
      * @test
      */
-    public function it_multiplies_other_money($multiplier, $roundingMode, $result)
+    public function it_multiplies_other_money($amount, $other, $result)
     {
-        $money = new Money(1, new Currency(self::CURRENCY));
-		$other = new Money($multiplier, new Currency(self::CURRENCY));
+        $money = new Money($amount, new Currency(self::CURRENCY));
+        $other = new Money($other, new Currency(self::CURRENCY));
 
-        $money = $money->multiply($other, $roundingMode);
+        $money = $money->multiply($other, Money::ROUND_HALF_UP);
 
         $this->assertInstanceOf(Money::class, $money);
         $this->assertEquals((string) $result, $money->getAmount());
     }
 
     /**
-     * @dataProvider roundExamples
+     * @dataProvider divideOtherExamples
+     * @test
      */
-    public function it_divides_other_money($divisor, $roundingMode, $result)
+    public function it_divides_other_money($amount, $other, $roundingMode, $result)
     {
-        $money = new Money(1, new Currency(self::CURRENCY));
-		$oher = new Money(1 / $divisor, new Currency(self::CURRENCY));
+        $money = new Money($amount, new Currency(self::CURRENCY));
+        $oher = new Money($other, new Currency(self::CURRENCY));
 
         $money = $money->divide($oher, $roundingMode);
 

--- a/tests/MoneyTest.php
+++ b/tests/MoneyTest.php
@@ -296,4 +296,37 @@ final class MoneyTest extends \PHPUnit_Framework_TestCase
             ['-1', 1],
         ];
     }
+	
+	
+	
+	
+    /**
+     * @dataProvider roundExamples
+     * @test
+     */
+    public function it_multiplies_other_money($multiplier, $roundingMode, $result)
+    {
+        $money = new Money(1, new Currency(self::CURRENCY));
+		$other = new Money($multiplier, new Currency(self::CURRENCY));
+
+        $money = $money->multiply($other, $roundingMode);
+
+        $this->assertInstanceOf(Money::class, $money);
+        $this->assertEquals((string) $result, $money->getAmount());
+    }
+
+    /**
+     * @dataProvider roundExamples
+     */
+    public function it_divides_other_money($divisor, $roundingMode, $result)
+    {
+        $money = new Money(1, new Currency(self::CURRENCY));
+		$oher = new Money(1 / $divisor, new Currency(self::CURRENCY));
+
+        $money = $money->divide($oher, $roundingMode);
+
+        $this->assertInstanceOf(Money::class, $money);
+        $this->assertEquals((string) $result, $money->getAmount());
+    }
+
 }


### PR DESCRIPTION
Added support to 

### Example

```php
$money = new Money(10, new Currency('BRL'));
$other = new Money(30, new Currency('BRL'));
$result = $money->multiply($other);

echo $result->getAmount(); // 300
```

### Note
Both **Money** instances must have identical **Currencies**