### PR TITLE
Add IndirectExchange

### DIFF
--- a/src/Exchange/IndirectExchange.php
+++ b/src/Exchange/IndirectExchange.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace Money\Exchange;
+
+use Money\Currencies;
+use Money\Currency;
+use Money\CurrencyPair;
+use Money\Exception\UnresolvableCurrencyPairException;
+use Money\Exchange;
+use SplQueue;
+use stdClass;
+
+/**
+ * Provides a way to get an exchange rate through a minimal set of intermediate conversions.
+ *
+ * @author Michael Cordingley <Michael.Cordingley@gmail.com>
+ */
+final class IndirectExchange implements Exchange
+{
+    /**
+     * @var Currencies
+     */
+    private $currencies;
+
+    /**
+     * @var Exchange
+     */
+    private $exchange;
+
+    /**
+     * @param Exchange $exchange
+     * @param Currencies $currencies
+     */
+    public function __construct(Exchange $exchange, Currencies $currencies)
+    {
+        $this->exchange = $exchange;
+        $this->currencies = $currencies;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function quote(Currency $baseCurrency, Currency $counterCurrency)
+    {
+        $rate = array_reduce($this->getConversions($baseCurrency, $counterCurrency), function ($carry, CurrencyPair $pair) {
+            return $carry * $pair->getConversionRatio();
+        }, 1.0);
+
+        return new CurrencyPair($baseCurrency, $counterCurrency, $rate);
+    }
+
+    /**
+     * @param Currency $baseCurrency
+     * @param Currency $counterCurrency
+     * @return CurrencyPair[]
+     * @throws UnresolvableCurrencyPairException
+     */
+    private function getConversions(Currency $baseCurrency, Currency $counterCurrency)
+    {
+        $nodes = $this->initializeNodes();
+
+        $startNode = $nodes[$baseCurrency->getCode()];
+        $startNode->discovered = true;
+
+        $frontier = new SplQueue();
+        $frontier->enqueue($startNode);
+
+        while ($frontier->count()) {
+            /** @var stdClass $currentNode */
+            $currentNode = $frontier->dequeue();
+
+            /** @var Currency $currentCurrency */
+            $currentCurrency = $currentNode->currency;
+
+            if ($currentCurrency->equals($counterCurrency)) {
+                return $this->reconstructConversionChain($nodes, $currentNode);
+            }
+
+            /** @var Currency $candidateCurrency */
+            foreach ($this->currencies as $candidateCurrency) {
+                /** @var stdClass $node */
+                $node = $nodes[$candidateCurrency->getCode()];
+
+                if (!$node->discovered) {
+                    try {
+                        // Check if the candidate is a neighbor. This will thrown an exception if it isn't.
+                        $this->exchange->quote($currentCurrency, $candidateCurrency);
+
+                        $node->discovered = true;
+                        $node->parent = $currentNode;
+
+                        $frontier->enqueue($node);
+                    } catch (UnresolvableCurrencyPairException $exception) {
+                        // Not a neighbor. Move on.
+                    }
+                }
+            }
+        }
+
+        throw UnresolvableCurrencyPairException::createFromCurrencies($baseCurrency, $counterCurrency);
+    }
+
+    /**
+     * @return stdClass[]
+     */
+    private function initializeNodes()
+    {
+        $currencies = [];
+
+        /** @var Currency $currency */
+        foreach ($this->currencies as $currency) {
+            $node = new stdClass;
+
+            $node->currency = $currency;
+            $node->discovered = false;
+            $node->parent = null;
+
+            $currencies[$currency->getCode()] = $node;
+        }
+
+        return $currencies;
+    }
+
+    /**
+     * @param array $currencies
+     * @param stdClass $goalNode
+     * @return CurrencyPair[]
+     */
+    private function reconstructConversionChain(array $currencies, stdClass $goalNode)
+    {
+        $current = $goalNode;
+        $conversions = [];
+
+        while ($current->parent) {
+            $previous = $currencies[$current->parent->currency->getCode()];
+            $conversions[] = $this->exchange->quote($previous->currency, $current->currency);
+            $current = $previous;
+        }
+
+        return array_reverse($conversions);
+    }
+}

--- a/tests/Exchange/IndirectExchangeTest.php
+++ b/tests/Exchange/IndirectExchangeTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Tests\Money\Exchange;
+
+use Money\Currencies\ISOCurrencies;
+use Money\Currency;
+use Money\Exception\UnresolvableCurrencyPairException;
+use Money\Exchange\FixedExchange;
+use Money\Exchange\IndirectExchange;
+
+final class IndirectExchangeTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @test
+     */
+    public function it_calculates_a_minimal_chain()
+    {
+        $exchange = $this->createExchange();
+
+        $pair = $exchange->quote(new Currency('USD'), new Currency('AOA'));
+
+        // USD => EUR => AOA
+        static::assertEquals('USD', $pair->getBaseCurrency()->getCode());
+        static::assertEquals('AOA', $pair->getCounterCurrency()->getCode());
+        static::assertEquals(12, $pair->getConversionRatio());
+    }
+
+    private function createExchange()
+    {
+        $baseExchange = new FixedExchange([
+            'USD' => [
+                'AFN' => 2,
+                'EUR' => 4,
+            ],
+            'AFN' => [
+                'DZD' => 12,
+                'EUR' => 8,
+            ],
+            'EUR' => [
+                'AOA' => 3,
+            ],
+            'DZD' => [
+                'AOA' => 5,
+                'USD' => 2,
+            ],
+            'ARS' => [
+                'AOA' => 2,
+            ],
+        ]);
+
+        return new IndirectExchange($baseExchange, new ISOCurrencies);
+    }
+
+    /**
+     * @test
+     */
+    public function it_calcualates_adjacent_nodes()
+    {
+        $exchange = $this->createExchange();
+
+        $pair = $exchange->quote(new Currency('USD'), new Currency('EUR'));
+
+        static::assertEquals('USD', $pair->getBaseCurrency()->getCode());
+        static::assertEquals('EUR', $pair->getCounterCurrency()->getCode());
+        static::assertEquals(4, $pair->getConversionRatio());
+    }
+
+    /**
+     * @test
+     */
+    public function it_throws_when_no_chain_is_found()
+    {
+        $exchange = $this->createExchange();
+
+        static::setExpectedException(UnresolvableCurrencyPairException::class);
+
+        $exchange->quote(new Currency('USD'), new Currency('ARS'));
+    }
+}


### PR DESCRIPTION
Adds a decorator for `Exchange` that will query the underlying exchange to find a shortest chain of conversions to go from the base currency to the counter currency using breadth-first search.