### PR TITLE
Allow Parsers to take Currency object as the forceCurrency parameter

### DIFF
--- a/spec/Parser/IntlMoneyParserSpec.php
+++ b/spec/Parser/IntlMoneyParserSpec.php
@@ -30,12 +30,13 @@ final class IntlMoneyParserSpec extends ObjectBehavior
 
     function it_parses_money(\NumberFormatter $numberFormatter, Currencies $currencies)
     {
-        $currency = null;
+        $currencyString = null;
 
-        $numberFormatter->parseCurrency('€1.00', $currency)->willReturn(1);
+        $numberFormatter->parseCurrency('€1.00', $currencyString)->willReturn(1);
         $currencies->subunitFor(Argument::type(Currency::class))->willReturn(2);
 
-        $money = $this->parse('€1.00', 'EUR');
+        $currency = new Currency('EUR');
+        $money = $this->parse('€1.00', $currency);
 
         $money->shouldHaveType(Money::class);
         $money->getAmount()->shouldReturn('100');
@@ -44,11 +45,13 @@ final class IntlMoneyParserSpec extends ObjectBehavior
 
     function it_throws_an_exception_when_money_cannot_be_parsed(\NumberFormatter $numberFormatter)
     {
-        $currency = null;
+        $currencyString = null;
 
-        $numberFormatter->parseCurrency('INVALID', $currency)->willReturn(false);
+        $numberFormatter->parseCurrency('INVALID', $currencyString)->willReturn(false);
         $numberFormatter->getErrorMessage()->willReturn('Some message');
 
-        $this->shouldThrow(ParserException::class)->duringParse('INVALID', 'EUR');
+        $currency = new Currency('EUR');
+
+        $this->shouldThrow(ParserException::class)->duringParse('INVALID', $currency);
     }
 }

--- a/src/MoneyParser.php
+++ b/src/MoneyParser.php
@@ -12,8 +12,8 @@ interface MoneyParser
     /**
      * Parses a string into a Money object (including currency).
      *
-     * @param string      $money
-     * @param string|null $forceCurrency
+     * @param string     $money
+     * @param mixed|null $forceCurrency
      *
      * @return Money
      *

--- a/src/MoneyParser.php
+++ b/src/MoneyParser.php
@@ -12,8 +12,8 @@ interface MoneyParser
     /**
      * Parses a string into a Money object (including currency).
      *
-     * @param string     $money
-     * @param mixed|null $forceCurrency
+     * @param string               $money
+     * @param Currency|string|null $forceCurrency
      *
      * @return Money
      *

--- a/src/Parser/DecimalMoneyParser.php
+++ b/src/Parser/DecimalMoneyParser.php
@@ -46,7 +46,15 @@ final class DecimalMoneyParser implements MoneyParser
             );
         }
 
-        $currency = new Currency($forceCurrency);
+        /*
+         * This conversion is only required whilst currency can be either a string or a
+         * Currency object.
+         */
+        $currency = $forceCurrency;
+        if (!$currency instanceof Currency) {
+            $currency = new Currency($currency);
+        }
+
         $decimal = trim($money);
 
         if ($decimal === '') {

--- a/src/Parser/DecimalMoneyParser.php
+++ b/src/Parser/DecimalMoneyParser.php
@@ -52,6 +52,7 @@ final class DecimalMoneyParser implements MoneyParser
          */
         $currency = $forceCurrency;
         if (!$currency instanceof Currency) {
+            @trigger_error('Passing a currency as string is deprecated since 3.1 and will be removed in 4.0. Please pass a '.Currency::class.' instance instead.', E_USER_DEPRECATED);
             $currency = new Currency($currency);
         }
 

--- a/src/Parser/IntlMoneyParser.php
+++ b/src/Parser/IntlMoneyParser.php
@@ -45,14 +45,8 @@ final class IntlMoneyParser implements MoneyParser
             throw new ParserException('Formatted raw money should be string, e.g. $1.00');
         }
 
-        $currencyCode = null;
-        $decimal = $this->formatter->parseCurrency($money, $currencyCode);
-
-        if (null !== $forceCurrency) {
-            $currencyCode = $forceCurrency;
-        }
-
-        $currency = new Currency($currencyCode);
+        $currency = null;
+        $decimal = $this->formatter->parseCurrency($money, $currency);
 
         if (false === $decimal) {
             throw new ParserException(
@@ -60,8 +54,21 @@ final class IntlMoneyParser implements MoneyParser
             );
         }
 
-        $decimal = (string) $decimal;
+        if (null !== $forceCurrency) {
+            $currency = $forceCurrency;
+        }
+
+        /*
+         * This conversion is only required whilst currency can be either a string or a
+         * Currency object.
+         */
+        if (!$currency instanceof Currency) {
+            $currency = new Currency($currency);
+        }
+
         $subunit = $this->currencies->subunitFor($currency);
+
+        $decimal = (string) $decimal;
         $decimalPosition = strpos($decimal, '.');
 
         if (false !== $decimalPosition) {

--- a/src/Parser/IntlMoneyParser.php
+++ b/src/Parser/IntlMoneyParser.php
@@ -63,12 +63,12 @@ final class IntlMoneyParser implements MoneyParser
          * Currency object.
          */
         if (!$currency instanceof Currency) {
+            @trigger_error('Passing a currency as string is deprecated since 3.1 and will be removed in 4.0. Please pass a '.Currency::class.' instance instead.', E_USER_DEPRECATED);
             $currency = new Currency($currency);
         }
 
-        $subunit = $this->currencies->subunitFor($currency);
-
         $decimal = (string) $decimal;
+        $subunit = $this->currencies->subunitFor($currency);
         $decimalPosition = strpos($decimal, '.');
 
         if (false !== $decimalPosition) {

--- a/tests/Parser/IntlMoneyParserTest.php
+++ b/tests/Parser/IntlMoneyParserTest.php
@@ -25,8 +25,11 @@ final class IntlMoneyParserTest extends \PHPUnit_Framework_TestCase
             Argument::which('getCode', 'USD')
         ))->willReturn(2);
 
+        $currencyCode = 'USD';
+        $currency = new Currency($currencyCode);
+
         $parser = new IntlMoneyParser($formatter, $currencies->reveal());
-        $this->assertEquals($units, $parser->parse($string, 'USD')->getAmount());
+        $this->assertEquals($units, $parser->parse($string, $currency)->getAmount());
     }
 
     public static function formattedMoneyExamples()
@@ -63,8 +66,10 @@ final class IntlMoneyParserTest extends \PHPUnit_Framework_TestCase
         $formatter = new \NumberFormatter('en_US', \NumberFormatter::CURRENCY);
         $formatter->setPattern('¤#,##0.00;-¤#,##0.00');
 
+        $currencyCode = 'USD';
+        $currency = new Currency($currencyCode);
         $parser = new IntlMoneyParser($formatter, new ISOCurrencies());
-        $parser->parse('THIS_IS_NOT_CONVERTABLE_TO_UNIT', 'USD');
+        $parser->parse('THIS_IS_NOT_CONVERTABLE_TO_UNIT', $currency);
     }
 
     public function testDifferentLocale()
@@ -79,13 +84,28 @@ final class IntlMoneyParserTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('CAD', $money->getCurrency()->getCode());
     }
 
-    public function testForceCurrency()
+    public function testCurrencyForceCurrency()
     {
         $formatter = new \NumberFormatter('en_US', \NumberFormatter::CURRENCY);
         $formatter->setPattern('¤#,##0.00;-¤#,##0.00');
 
+        $currencyCode = 'CAD';
+        $currency = new Currency($currencyCode);
         $parser = new IntlMoneyParser($formatter, new ISOCurrencies());
-        $money = $parser->parse('$1000.00', 'CAD');
+        $money = $parser->parse('$1000.00', $currency);
+
+        $this->assertEquals('100000', $money->getAmount());
+        $this->assertEquals('CAD', $money->getCurrency()->getCode());
+    }
+
+    public function testStringForceCurrency()
+    {
+        $formatter = new \NumberFormatter('en_US', \NumberFormatter::CURRENCY);
+        $formatter->setPattern('¤#,##0.00;-¤#,##0.00');
+
+        $currencyCode = 'CAD';
+        $parser = new IntlMoneyParser($formatter, new ISOCurrencies());
+        $money = $parser->parse('$1000.00', $currencyCode);
 
         $this->assertEquals('100000', $money->getAmount());
         $this->assertEquals('CAD', $money->getCurrency()->getCode());


### PR DESCRIPTION
Closes #386 

This adds support for $forceCurrency to either be a string or a Currency object.

If you'd rather wait until the next major version and just use the Currency object, let me know and I'll make changes.