### PR TITLE
Modulus support

### DIFF
--- a/doc/features/operation.rst
+++ b/doc/features/operation.rst
@@ -47,6 +47,20 @@ Divisions can be performed using ``divide()``.
 
     $result = $value->divide(2);    // €4.00
 
+.. _modulus:
+
+Modulus
+-------
+
+Modulus operations can be performed using ``mod()``.
+
+.. code-block:: php
+
+    $value = Money::EUR(830);        // €8.30
+    $divisor = Money::EUR(300);      // €3.00
+
+    $result = $value->mod($divisor); // €2.30
+
 .. _rounding_modes:
 
 Rounding Modes

--- a/spec/Calculator/CalculatorBehavior.php
+++ b/spec/Calculator/CalculatorBehavior.php
@@ -72,6 +72,11 @@ trait CalculatorBehavior
         $this->share(10, 2, 4)->shouldBeString();
     }
 
+    function it_calculates_the_modulus()
+    {
+        $this->mod(11, 5)->shouldBeString();
+    }
+
     public function getMatchers()
     {
         return [

--- a/spec/MoneySpec.php
+++ b/spec/MoneySpec.php
@@ -320,6 +320,23 @@ final class MoneySpec extends ObjectBehavior
         $money->getAmount()->shouldBeLike(1);
     }
 
+    function it_calculates_a_modulus_with_an_other_money(Calculator $calculator)
+    {
+        $result = self::AMOUNT % self::OTHER_AMOUNT;
+        $calculator->mod((string) self::AMOUNT, (string) self::OTHER_AMOUNT)->willReturn((string) $result);
+        $money = $this->mod(new Money(self::OTHER_AMOUNT, new Currency(self::CURRENCY)));
+
+        $money->shouldHaveType(Money::class);
+        $money->getAmount()->shouldBe((string) $result);
+    }
+
+    function it_throws_an_exception_when_currency_is_different_during_modulus(Calculator $calculator)
+    {
+        $calculator->mod((string) self::AMOUNT, (string) self::AMOUNT)->shouldNotBeCalled();
+
+        $this->shouldThrow(\InvalidArgumentException::class)->duringMod(new Money(self::AMOUNT, new Currency(self::OTHER_CURRENCY)));
+    }
+
     public function getMatchers()
     {
         return [

--- a/src/Calculator.php
+++ b/src/Calculator.php
@@ -114,4 +114,14 @@ interface Calculator
      * @return string
      */
     public function share($amount, $ratio, $total);
+
+    /**
+     * Get the modulus of an amount.
+     *
+     * @param string           $amount
+     * @param int|float|string $divisor
+     *
+     * @return string
+     */
+    public function mod($amount, $divisor);
 }

--- a/src/Calculator/BcMathCalculator.php
+++ b/src/Calculator/BcMathCalculator.php
@@ -228,4 +228,12 @@ final class BcMathCalculator implements Calculator
     {
         return $this->floor(bcdiv(bcmul($amount, $ratio, $this->scale), $total, $this->scale));
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function mod($amount, $divisor)
+    {
+        return bcmod($amount, $divisor);
+    }
 }

--- a/src/Calculator/GmpCalculator.php
+++ b/src/Calculator/GmpCalculator.php
@@ -286,4 +286,12 @@ final class GmpCalculator implements Calculator
     {
         return $this->floor($this->divide($this->multiply($amount, $ratio), $total));
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function mod($amount, $divisor)
+    {
+        return gmp_strval(gmp_mod($amount, $divisor));
+    }
 }

--- a/src/Calculator/GmpCalculator.php
+++ b/src/Calculator/GmpCalculator.php
@@ -292,6 +292,16 @@ final class GmpCalculator implements Calculator
      */
     public function mod($amount, $divisor)
     {
-        return gmp_strval(gmp_mod($amount, $divisor));
+        // gmp_mod() only calculates non-negative integers, so we use absolutes
+        $remainder = gmp_mod($this->absolute($amount), $this->absolute($divisor));
+
+        // If the amount was negative, we negate the result of the modulus operation
+        $amount = Number::fromString((string) $amount);
+
+        if (true === $amount->isNegative()) {
+            $remainder = gmp_neg($remainder);
+        }
+
+        return gmp_strval($remainder);
     }
 }

--- a/src/Calculator/PhpCalculator.php
+++ b/src/Calculator/PhpCalculator.php
@@ -140,6 +140,18 @@ final class PhpCalculator implements Calculator
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function mod($amount, $divisor)
+    {
+        $result = $amount % $divisor;
+
+        $this->assertIntegerBounds($result);
+
+        return (string) $result;
+    }
+
+    /**
      * Asserts that an integer value didn't become something else
      * (after some arithmetic operation).
      *

--- a/src/Money.php
+++ b/src/Money.php
@@ -343,6 +343,22 @@ final class Money implements \JsonSerializable
     }
 
     /**
+     * Returns a new Money object that represents
+     * the remainder after dividing the value by
+     * the given factor.
+     *
+     * @param Money $divisor
+     *
+     * @return Money
+     */
+    public function mod(Money $divisor)
+    {
+        $this->assertSameCurrency($divisor);
+
+        return new self($this->getCalculator()->mod($this->amount, $divisor->amount), $this->currency);
+    }
+
+    /**
      * Allocate the money according to a list of ratios.
      *
      * @param array $ratios

--- a/tests/Calculator/CalculatorTestCase.php
+++ b/tests/Calculator/CalculatorTestCase.php
@@ -215,6 +215,9 @@ abstract class CalculatorTestCase extends \PHPUnit_Framework_TestCase
             [9, 3, '0'],
             [1006, 10, '6'],
             [1007, 10, '7'],
+            [-13, -5, '-3'],
+            [-13, 5, '-3'],
+            [13, -5, '3'],
         ];
     }
 }

--- a/tests/Calculator/CalculatorTestCase.php
+++ b/tests/Calculator/CalculatorTestCase.php
@@ -105,6 +105,15 @@ abstract class CalculatorTestCase extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $this->getCalculator()->compare($left, $right));
     }
 
+    /**
+     * @dataProvider modExamples
+     * @test
+     */
+    public function it_calculates_the_modulus_of_a_value($left, $right, $expected)
+    {
+        $this->assertEquals($expected, $this->getCalculator()->mod($left, $right));
+    }
+
     public function additionExamples()
     {
         return [
@@ -196,6 +205,16 @@ abstract class CalculatorTestCase extends \PHPUnit_Framework_TestCase
             ['0', '1', -1],
             ['1', '0.0005', 1],
             ['1', '0.000000000000000000000000005', 1],
+        ];
+    }
+
+    public function modExamples()
+    {
+        return [
+            [11, 5, '1'],
+            [9, 3, '0'],
+            [1006, 10, '6'],
+            [1007, 10, '7'],
         ];
     }
 }

--- a/tests/MoneyTest.php
+++ b/tests/MoneyTest.php
@@ -197,8 +197,9 @@ final class MoneyTest extends \PHPUnit_Framework_TestCase
     public function it_calculates_the_modulus_of_an_amount($left, $right, $expected)
     {
         $money = new Money($left, new Currency(self::CURRENCY));
+        $rightMoney = new Money($right, new Currency(self::CURRENCY));
 
-        $money = $money->mod($left % $right);
+        $money = $money->mod($rightMoney);
 
         $this->assertInstanceOf(Money::class, $money);
         $this->assertEquals($expected, $money->getAmount());

--- a/tests/MoneyTest.php
+++ b/tests/MoneyTest.php
@@ -190,6 +190,20 @@ final class MoneyTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($result, $money->getAmount());
     }
 
+    /**
+     * @dataProvider modExamples
+     * @test
+     */
+    public function it_calculates_the_modulus_of_an_amount($left, $right, $expected)
+    {
+        $money = new Money($left, new Currency(self::CURRENCY));
+
+        $money = $money->mod($left % $right);
+
+        $this->assertInstanceOf(Money::class, $money);
+        $this->assertEquals($expected, $money->getAmount());
+    }
+
     public function test_it_converts_to_json()
     {
         $this->assertEquals(
@@ -294,6 +308,16 @@ final class MoneyTest extends \PHPUnit_Framework_TestCase
             ['1', -1],
             ['0', 0],
             ['-1', 1],
+        ];
+    }
+
+    public function modExamples()
+    {
+        return [
+            [11, 5, '1'],
+            [9, 3, '0'],
+            [1006, 10, '6'],
+            [1007, 10, '7'],
         ];
     }
 }


### PR DESCRIPTION
This PR adds `Money::mod()` to allow modulus operations.

We have a use-case for this whereby we need to transfer as large a value as possible from a user's balance in £5 increments. Currently this requires either looping, or arithmetic with raw amounts outside of the `Money` class.

With this PR, we can do:

```php
$balance = Money::GBP(1820); // £18.20
$incrementSize = Money::GBP(500); // £5.00

$newBalance = $balance->mod($incrementSize); // £3.20
$transferredBalance = $balance->subtract($newBalance); // £15.00
```