### PR TITLE
Docs are not needed when you install through composer

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
+/doc/             export-ignore
 /spec/            export-ignore
 /tests/           export-ignore
 /.editorconfig    export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 /doc/             export-ignore
+/resources/logo.png export-ignore
 /spec/            export-ignore
 /tests/           export-ignore
 /.editorconfig    export-ignore


### PR DESCRIPTION
Docs and logo I don't believe they are needed to be extracted when you install through composer.