### PR TITLE
Fix comparison operation

### DIFF
--- a/src/Calculator/BcMathCalculator.php
+++ b/src/Calculator/BcMathCalculator.php
@@ -37,7 +37,7 @@ final class BcMathCalculator implements Calculator
      */
     public function compare($a, $b)
     {
-        return bccomp($a, $b);
+        return bccomp($a, $b, $this->scale);
     }
 
     /**


### PR DESCRIPTION
The scale (precision) parameter was missing from the comparison operation, leading to wrong results.