### PR TITLE
Undefined Index "digits"

### DIFF
--- a/src/Parser/DecimalMoneyParser.php
+++ b/src/Parser/DecimalMoneyParser.php
@@ -64,7 +64,7 @@ final class DecimalMoneyParser implements MoneyParser
 
         $subunit = $this->currencies->subunitFor($currency);
 
-        if (!preg_match(self::DECIMAL_PATTERN, $decimal, $matches)) {
+        if (!preg_match(self::DECIMAL_PATTERN, $decimal, $matches) || !isset($matches['digits'])) {
             throw new ParserException(sprintf(
                 'Cannot parse "%s" to Money.',
                 $decimal

--- a/tests/Parser/DecimalMoneyParserTest.php
+++ b/tests/Parser/DecimalMoneyParserTest.php
@@ -87,6 +87,7 @@ final class DecimalMoneyParserTest extends \PHPUnit_Framework_TestCase
     {
         return [
             ['INVALID'],
+            ['.'],
         ];
     }
 

--- a/tests/Parser/DecimalMoneyParserTest.php
+++ b/tests/Parser/DecimalMoneyParserTest.php
@@ -82,4 +82,29 @@ final class DecimalMoneyParserTest extends \PHPUnit_Framework_TestCase
             ['-9.99', 'USD', 2, -999],
         ];
     }
+
+    public static function invalidMoneyExamples()
+    {
+        return [
+            ['INVALID'],
+        ];
+    }
+
+    /**
+     * @dataProvider invalidMoneyExamples
+     * @expectedException \Money\Exception\ParserException
+     */
+    public function testInvalidInputsThrowParseException($input)
+    {
+        $currencies = $this->prophesize(Currencies::class);
+
+        $currencies->subunitFor(Argument::allOf(
+            Argument::type(Currency::class),
+            Argument::which('getCode', 'USD')
+        ))->willReturn(2);
+
+        $parser = new DecimalMoneyParser($currencies->reveal());
+
+        $parser->parse($input, 'USD')->getAmount();
+    }
 }


### PR DESCRIPTION
When trying to parse invalid input I'm seeing an undefined index error for `digits` (php strict mode).

```
Undefined index: digits

/Users/rod/Code/misc/money/src/Parser/DecimalMoneyParser.php:76
```

I've added a test for the handling of invalid inputs, but not sure what the behaviour here should be (though I assume it should result in a ParserException somehow so it can be gracefully handled by the caller).