### PR TITLE
Fix deprecation notice for IntlMoneyParser

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^4.5",
+        "symfony/phpunit-bridge": "^3.4.2 || ^4.0",
         "ext-bcmath": "*",
         "ext-gmp": "*",
         "ext-intl": "*",
@@ -62,7 +63,7 @@
         ],
         "test-ci": [
             "vendor/bin/phpspec run -c phpspec.ci.yml",
-            "vendor/bin/phpunit --coverage-text --coverage-clover=build/unit_coverage.xml"
+            "SYMFONY_DEPRECATIONS_HELPER=\"/The each\\(\\) function is deprecated/\" vendor/bin/phpunit --coverage-text --coverage-clover=build/unit_coverage.xml"
         ],
         "update-currencies": "cp vendor/moneyphp/iso-currencies/resources/current.php resources/currency.php"
     },

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -11,4 +11,8 @@
             <directory suffix=".php">src</directory>
         </whitelist>
     </filter>
+
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
+    </listeners>
 </phpunit>

--- a/src/Parser/IntlMoneyParser.php
+++ b/src/Parser/IntlMoneyParser.php
@@ -56,6 +56,8 @@ final class IntlMoneyParser implements MoneyParser
 
         if (null !== $forceCurrency) {
             $currency = $forceCurrency;
+        } else {
+            $currency = new Currency($currency);
         }
 
         /*

--- a/tests/Parser/DecimalMoneyParserTest.php
+++ b/tests/Parser/DecimalMoneyParserTest.php
@@ -24,7 +24,7 @@ final class DecimalMoneyParserTest extends \PHPUnit_Framework_TestCase
 
         $parser = new DecimalMoneyParser($currencies->reveal());
 
-        $this->assertEquals($result, $parser->parse($decimal, $currency)->getAmount());
+        $this->assertEquals($result, $parser->parse($decimal, new Currency($currency))->getAmount());
     }
 
     public static function formattedMoneyExamples()
@@ -106,6 +106,24 @@ final class DecimalMoneyParserTest extends \PHPUnit_Framework_TestCase
 
         $parser = new DecimalMoneyParser($currencies->reveal());
 
-        $parser->parse($input, 'USD')->getAmount();
+        $parser->parse($input, new Currency('USD'))->getAmount();
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation Passing a currency as string is deprecated since 3.1 and will be removed in 4.0. Please pass a Money\Currency instance instead.
+     */
+    public function testCurrencyExpectsAnObject()
+    {
+        $currencies = $this->prophesize(Currencies::class);
+
+        $currencies->subunitFor(Argument::allOf(
+            Argument::type(Currency::class),
+            Argument::which('getCode', 'USD')
+        ))->willReturn(2);
+
+        $parser = new DecimalMoneyParser($currencies->reveal());
+
+        $parser->parse('1.0', 'USD')->getAmount();
     }
 }

--- a/tests/Parser/IntlMoneyParserTest.php
+++ b/tests/Parser/IntlMoneyParserTest.php
@@ -105,7 +105,7 @@ final class IntlMoneyParserTest extends \PHPUnit_Framework_TestCase
 
         $currencyCode = 'CAD';
         $parser = new IntlMoneyParser($formatter, new ISOCurrencies());
-        $money = $parser->parse('$1000.00', $currencyCode);
+        $money = $parser->parse('$1000.00', new Currency($currencyCode));
 
         $this->assertEquals('100000', $money->getAmount());
         $this->assertEquals('CAD', $money->getCurrency()->getCode());
@@ -133,5 +133,18 @@ final class IntlMoneyParserTest extends \PHPUnit_Framework_TestCase
         $money = $parser->parse('$1000.005');
 
         $this->assertEquals('100001', $money->getAmount());
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation Passing a currency as string is deprecated since 3.1 and will be removed in 4.0. Please pass a Money\Currency instance instead.
+     */
+    public function testForceCurrencyExpectsAnObject()
+    {
+        $formatter = new \NumberFormatter('en_CA', \NumberFormatter::CURRENCY);
+        $formatter->setPattern('¤#,##0.00;-¤#,##0.00');
+
+        $parser = new IntlMoneyParser($formatter, new ISOCurrencies());
+        $parser->parse('$1000.00', 'EUR');
     }
 }


### PR DESCRIPTION
The IntlMoneyParser use the Intl NumberFormatter to parse a currency, and assigns the currency to a variable. But later-on the if statement throws an deprecation warning because the currency is not a `Currency` object.

The actual deprecation notice was never shown as it's silenced and the Symfony PHPUnit bridge was not installed.