### PR TITLE
Converter float precision

### DIFF
--- a/src/Converter.php
+++ b/src/Converter.php
@@ -39,13 +39,13 @@ final class Converter
     public function convert(Money $money, Currency $counterCurrency, $roundingMode = Money::ROUND_HALF_UP)
     {
         $baseCurrency = $money->getCurrency();
-        $ratio = (string) $this->exchange->quote($baseCurrency, $counterCurrency)->getConversionRatio();
+        $ratio = $this->exchange->quote($baseCurrency, $counterCurrency)->getConversionRatio();
 
         $baseCurrencySubunit = $this->currencies->subunitFor($baseCurrency);
         $counterCurrencySubunit = $this->currencies->subunitFor($counterCurrency);
         $subunitDifference = $baseCurrencySubunit - $counterCurrencySubunit;
 
-        $ratio = (string) Number::fromString($ratio)->base10($subunitDifference);
+        $ratio = (string) Number::fromFloat($ratio)->base10($subunitDifference);
 
         $counterValue = $money->multiply($ratio, $roundingMode);
 

--- a/src/Number.php
+++ b/src/Number.php
@@ -125,7 +125,7 @@ final class Number
             throw new \InvalidArgumentException('Floating point expected');
         }
 
-        return self::fromString(sprintf('%.8F', $floatingPoint));
+        return self::fromString(sprintf('%.14F', $floatingPoint));
     }
 
     /**

--- a/src/Number.php
+++ b/src/Number.php
@@ -117,7 +117,7 @@ final class Number
     /**
      * @param float $floatingPoint
      *
-     * @return Number
+     * @return self
      */
     public static function fromFloat($floatingPoint)
     {

--- a/tests/ConverterTest.php
+++ b/tests/ConverterTest.php
@@ -63,6 +63,8 @@ final class ConverterTest extends \PHPUnit_Framework_TestCase
             ['XBT', 'USD', 8, 2, 6597, 10, 0],
             ['XBT', 'USD', 8, 2, 6597, 100, 1],
             ['ETH', 'EUR', 18, 2, 330.84, '100000000000000000', 3308],
+            ['BTC', 'USD', 8, 2, 13500, 100000000, 1350000],
+            ['USD', 'BTC', 2, 8, 1 / 13500, 1350000, 100000000],
         ];
     }
 }


### PR DESCRIPTION
I think this should fix https://github.com/moneyphp/money/issues/444.

This issue is the converter didn't deal with very small ratios, (e.g. USD->BTC) due to the casting of a float to a string.

For this to work, I also had to increase the precision in the `Number::fromFloat` method. 
I just picked the same default as used for the scale of the calculators. 
I have no other rational - help welcome!