### PR TITLE
Remove HHVM from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ php:
     - 7.0
     - 7.1
     - 7.2
-    - hhvm
 
 env:
     global:


### PR DESCRIPTION
Or we should add a `.hhconfig` as suggested in the [latest failing Travis build](https://travis-ci.org/moneyphp/money/jobs/337577634). I rather drop HHVM from testing and let people do a PR if something fails for HHVM.