### PR TITLE
Fix KRW minorUnit

### DIFF
--- a/resources/currency.php
+++ b/resources/currency.php
@@ -591,7 +591,7 @@
   array (
     'alphabeticCode' => 'KRW',
     'currency' => 'Won',
-    'minorUnit' => 0,
+    'minorUnit' => 2,
     'numericCode' => 410,
   ),
   'KWD' => 


### PR DESCRIPTION
minorUnit in case of South Korea Won must be 2 as specified by xe.com (http://www.xe.com/it/currency/krw-south-korean-won)