### PR TITLE
the calculator is optionally set by the programmer in the instantiation

### DIFF
--- a/src/Money.php
+++ b/src/Money.php
@@ -2,6 +2,7 @@
 
 namespace Money;
 
+use Money\Calculator;
 use Money\Calculator\BcMathCalculator;
 use Money\Calculator\GmpCalculator;
 use Money\Calculator\PhpCalculator;
@@ -63,7 +64,7 @@ final class Money implements \JsonSerializable
      *
      * @throws \InvalidArgumentException If amount is not integer
      */
-    public function __construct($amount, Currency $currency)
+    public function __construct($amount, Currency $currency, Calculator $calculator = null)
     {
         if (filter_var($amount, FILTER_VALIDATE_INT) === false) {
             $numberFromString = Number::fromString($amount);
@@ -76,6 +77,7 @@ final class Money implements \JsonSerializable
 
         $this->amount = (string) $amount;
         $this->currency = $currency;
+        self::$calculator = $calculator;
     }
 
     /**

--- a/src/MoneyFactory.php
+++ b/src/MoneyFactory.php
@@ -202,6 +202,6 @@ trait MoneyFactory
      */
     public static function __callStatic($method, $arguments)
     {
-        return new Money($arguments[0], new Currency($method));
+        return new Money($arguments[0], new Currency($method), $arguments[1]);
     }
 }

--- a/tests/MoneyFactoryTest.php
+++ b/tests/MoneyFactoryTest.php
@@ -2,6 +2,9 @@
 
 namespace Tests\Money;
 
+use Money\Calculator\BcMathCalculator;
+use Money\Calculator\GmpCalculator;
+use Money\Calculator\PhpCalculator;
 use Money\Currencies\AggregateCurrencies;
 use Money\Currencies\BitcoinCurrencies;
 use Money\Currencies\ISOCurrencies;
@@ -22,6 +25,45 @@ final class MoneyFactoryTest extends TestCase
 
         $this->assertInstanceOf(Money::class, $money);
         $this->assertEquals(new Money(20, $currency), $money);
+    }
+
+    /**
+     * @dataProvider currencyExamples
+     * @test
+     */
+    public function it_creates_money_using_factories_with_bcmath_calculator(Currency $currency)
+    {
+        $code = $currency->getCode();
+        $money = Money::{$code}(20, new BcMathCalculator());
+
+        $this->assertInstanceOf(Money::class, $money);
+        $this->assertEquals(new Money(20, $currency, new BcMathCalculator()), $money);
+    }
+
+    /**
+     * @dataProvider currencyExamples
+     * @test
+     */
+    public function it_creates_money_using_factories_with_gmp_calculator(Currency $currency)
+    {
+        $code = $currency->getCode();
+        $money = Money::{$code}(20, new GmpCalculator());
+
+        $this->assertInstanceOf(Money::class, $money);
+        $this->assertEquals(new Money(20, $currency, new GmpCalculator()), $money);
+    }
+
+    /**
+     * @dataProvider currencyExamples
+     * @test
+     */
+    public function it_creates_money_using_factories_with_php_calculator(Currency $currency)
+    {
+        $code = $currency->getCode();
+        $money = Money::{$code}(20, new PhpCalculator());
+
+        $this->assertInstanceOf(Money::class, $money);
+        $this->assertEquals(new Money(20, $currency, new PhpCalculator()), $money);
     }
 
     public function currencyExamples()

--- a/tests/MoneyTest.php
+++ b/tests/MoneyTest.php
@@ -4,6 +4,9 @@ namespace Tests\Money;
 
 use Money\Currency;
 use Money\Money;
+use Money\Calculator\BcMathCalculator;
+use Money\Calculator\GmpCalculator;
+use Money\Calculator\PhpCalculator;
 use PHPUnit\Framework\TestCase;
 
 final class MoneyTest extends TestCase
@@ -25,6 +28,39 @@ final class MoneyTest extends TestCase
     public function it_equals_to_another_money($amount, $currency, $equality)
     {
         $money = new Money(self::AMOUNT, new Currency(self::CURRENCY));
+
+        $this->assertEquals($equality, $money->equals(new Money($amount, $currency)));
+    }
+
+    /**
+     * @dataProvider equalityExamples
+     * @test
+     */
+    public function it_equals_to_another_money_with_bcmath_calculator($amount, $currency, $equality)
+    {
+        $money = new Money(self::AMOUNT, new Currency(self::CURRENCY), new BcMathCalculator());
+
+        $this->assertEquals($equality, $money->equals(new Money($amount, $currency)));
+    }
+
+    /**
+     * @dataProvider equalityExamples
+     * @test
+     */
+    public function it_equals_to_another_money_with_gmp_calculator($amount, $currency, $equality)
+    {
+        $money = new Money(self::AMOUNT, new Currency(self::CURRENCY), new GmpCalculator());
+
+        $this->assertEquals($equality, $money->equals(new Money($amount, $currency)));
+    }
+
+    /**
+     * @dataProvider equalityExamples
+     * @test
+     */
+    public function it_equals_to_another_money_with_php_calculator($amount, $currency, $equality)
+    {
+        $money = new Money(self::AMOUNT, new Currency(self::CURRENCY), new PhpCalculator());
 
         $this->assertEquals($equality, $money->equals(new Money($amount, $currency)));
     }
@@ -52,12 +88,120 @@ final class MoneyTest extends TestCase
     }
 
     /**
+     * @dataProvider comparisonExamples
+     * @test
+     */
+    public function it_compares_two_amounts_with_bcmath_calculator($other, $result)
+    {
+        $money = new Money(self::AMOUNT, new Currency(self::CURRENCY), new BcMathCalculator());
+        $other = new Money($other, new Currency(self::CURRENCY), new BcMathCalculator());
+
+        $this->assertEquals($result, $money->compare($other));
+        $this->assertEquals(1 === $result, $money->greaterThan($other));
+        $this->assertEquals(0 <= $result, $money->greaterThanOrEqual($other));
+        $this->assertEquals(-1 === $result, $money->lessThan($other));
+        $this->assertEquals(0 >= $result, $money->lessThanOrEqual($other));
+
+        if ($result === 0) {
+            $this->assertEquals($money, $other);
+        } else {
+            $this->assertNotEquals($money, $other);
+        }
+    }
+
+    /**
+     * @dataProvider comparisonExamples
+     * @test
+     */
+    public function it_compares_two_amounts_with_gmp_calculator($other, $result)
+    {
+        $money = new Money(self::AMOUNT, new Currency(self::CURRENCY), new GmpCalculator());
+        $other = new Money($other, new Currency(self::CURRENCY), new GmpCalculator());
+
+        $this->assertEquals($result, $money->compare($other));
+        $this->assertEquals(1 === $result, $money->greaterThan($other));
+        $this->assertEquals(0 <= $result, $money->greaterThanOrEqual($other));
+        $this->assertEquals(-1 === $result, $money->lessThan($other));
+        $this->assertEquals(0 >= $result, $money->lessThanOrEqual($other));
+
+        if ($result === 0) {
+            $this->assertEquals($money, $other);
+        } else {
+            $this->assertNotEquals($money, $other);
+        }
+    }
+
+    /**
+     * @dataProvider comparisonExamples
+     * @test
+     */
+    public function it_compares_two_amounts_with_php_calculator($other, $result)
+    {
+        $money = new Money(self::AMOUNT, new Currency(self::CURRENCY), new PhpCalculator());
+        $other = new Money($other, new Currency(self::CURRENCY), new PhpCalculator());
+
+        $this->assertEquals($result, $money->compare($other));
+        $this->assertEquals(1 === $result, $money->greaterThan($other));
+        $this->assertEquals(0 <= $result, $money->greaterThanOrEqual($other));
+        $this->assertEquals(-1 === $result, $money->lessThan($other));
+        $this->assertEquals(0 >= $result, $money->lessThanOrEqual($other));
+
+        if ($result === 0) {
+            $this->assertEquals($money, $other);
+        } else {
+            $this->assertNotEquals($money, $other);
+        }
+    }
+
+    /**
      * @dataProvider roundExamples
      * @test
      */
     public function it_multiplies_the_amount($multiplier, $roundingMode, $result)
     {
         $money = new Money(1, new Currency(self::CURRENCY));
+
+        $money = $money->multiply($multiplier, $roundingMode);
+
+        $this->assertInstanceOf(Money::class, $money);
+        $this->assertEquals((string) $result, $money->getAmount());
+    }
+
+    /**
+     * @dataProvider roundExamples
+     * @test
+     */
+    public function it_multiplies_the_amount_with_bcmath_calculator($multiplier, $roundingMode, $result)
+    {
+        $money = new Money(1, new Currency(self::CURRENCY), new BcMathCalculator());
+
+        $money = $money->multiply($multiplier, $roundingMode);
+
+        $this->assertInstanceOf(Money::class, $money);
+        $this->assertEquals((string) $result, $money->getAmount());
+    }
+
+    /**
+     * @dataProvider roundExamples
+     * @test
+     */
+    public function it_multiplies_the_amount_with_gmp_calculator($multiplier, $roundingMode, $result)
+    {
+        $money = new Money(1, new Currency(self::CURRENCY), new GmpCalculator());
+
+        $money = $money->multiply($multiplier, $roundingMode);
+
+        $this->assertInstanceOf(Money::class, $money);
+        $this->assertEquals((string) $result, $money->getAmount());
+    }
+
+    /**
+     * @dataProvider roundExamples
+     * @test
+     */
+    public function it_multiplies_the_amount_with_php_calculator($multiplier, $roundingMode, $result)
+    {
+        $money = new Money(1, new Currency(self::CURRENCY), new PhpCalculator());
 
         $money = $money->multiply($multiplier, $roundingMode);
 
@@ -98,6 +242,45 @@ final class MoneyTest extends TestCase
     public function it_divides_the_amount($divisor, $roundingMode, $result)
     {
         $money = new Money(1, new Currency(self::CURRENCY));
+
+        $money = $money->divide(1 / $divisor, $roundingMode);
+
+        $this->assertInstanceOf(Money::class, $money);
+        $this->assertEquals((string) $result, $money->getAmount());
+    }
+
+    /**
+     * @dataProvider roundExamples
+     */
+    public function it_divides_the_amount_with_bcmath_calculator($divisor, $roundingMode, $result)
+    {
+        $money = new Money(1, new Currency(self::CURRENCY), new BcMathCalculator());
+
+        $money = $money->divide(1 / $divisor, $roundingMode);
+
+        $this->assertInstanceOf(Money::class, $money);
+        $this->assertEquals((string) $result, $money->getAmount());
+    }
+
+    /**
+     * @dataProvider roundExamples
+     */
+    public function it_divides_the_amount_with_gmp_calculator($divisor, $roundingMode, $result)
+    {
+        $money = new Money(1, new Currency(self::CURRENCY), new GmpCalculator());
+
+        $money = $money->divide(1 / $divisor, $roundingMode);
+
+        $this->assertInstanceOf(Money::class, $money);
+        $this->assertEquals((string) $result, $money->getAmount());
+    }
+
+    /**
+     * @dataProvider roundExamples
+     */
+    public function it_divides_the_amount_with_php_calculator($divisor, $roundingMode, $result)
+    {
+        $money = new Money(1, new Currency(self::CURRENCY), new PhpCalculator());
 
         $money = $money->divide(1 / $divisor, $roundingMode);
 
@@ -179,12 +362,90 @@ final class MoneyTest extends TestCase
     }
 
     /**
+     * @dataProvider absoluteExamples
+     * @test
+     */
+    public function it_calculates_the_absolute_amount_with_bcmath_calculator($amount, $result)
+    {
+        $money = new Money($amount, new Currency(self::CURRENCY), new BcMathCalculator());
+
+        $money = $money->absolute();
+
+        $this->assertEquals($result, $money->getAmount());
+    }
+
+    /**
+     * @dataProvider absoluteExamples
+     * @test
+     */
+    public function it_calculates_the_absolute_amount_with_gmp_calculator($amount, $result)
+    {
+        $money = new Money($amount, new Currency(self::CURRENCY), new GmpCalculator());
+
+        $money = $money->absolute();
+
+        $this->assertEquals($result, $money->getAmount());
+    }
+
+    /**
+     * @dataProvider absoluteExamples
+     * @test
+     */
+    public function it_calculates_the_absolute_amount_with_php_calculator($amount, $result)
+    {
+        $money = new Money($amount, new Currency(self::CURRENCY), new PhpCalculator());
+
+        $money = $money->absolute();
+
+        $this->assertEquals($result, $money->getAmount());
+    }
+
+    /**
      * @dataProvider negativeExamples
      * @test
      */
     public function it_calculates_the_negative_amount($amount, $result)
     {
         $money = new Money($amount, new Currency(self::CURRENCY));
+
+        $money = $money->negative();
+
+        $this->assertEquals($result, $money->getAmount());
+    }
+
+    /**
+     * @dataProvider negativeExamples
+     * @test
+     */
+    public function it_calculates_the_negative_amount_with_bcmath_calculator($amount, $result)
+    {
+        $money = new Money($amount, new Currency(self::CURRENCY), new BcMathCalculator());
+
+        $money = $money->negative();
+
+        $this->assertEquals($result, $money->getAmount());
+    }
+
+    /**
+     * @dataProvider negativeExamples
+     * @test
+     */
+    public function it_calculates_the_negative_amount_with_gmp_calculator($amount, $result)
+    {
+        $money = new Money($amount, new Currency(self::CURRENCY), new GmpCalculator());
+
+        $money = $money->negative();
+
+        $this->assertEquals($result, $money->getAmount());
+    }
+
+    /**
+     * @dataProvider negativeExamples
+     * @test
+     */
+    public function it_calculates_the_negative_amount_with_php_calculator($amount, $result)
+    {
+        $money = new Money($amount, new Currency(self::CURRENCY), new PhpCalculator());
 
         $money = $money->negative();
 


### PR DESCRIPTION
Hi there,

This is the continuation of 

- https://github.com/moneyphp/money/pull/389
- https://github.com/programarivm/money-pattern

Sorry for bringing this topic up again. Just wondering if `moneyphp/money` could take this issue into consideration.

Safe examples:
```
$fiveEur = Money::EUR(500, new PhpCalculator());
$tenEur = new Money(1000, new Currency('EUR'), new PhpCalculator());
```

This way, the programmer can optionally set the calculator of their choice when instantiating `Money` objects -- regardless of the server settings.