### PR TITLE
Parsing very very tiny float.

### DIFF
--- a/tests/Parser/DecimalMoneyParserTest.php
+++ b/tests/Parser/DecimalMoneyParserTest.php
@@ -5,6 +5,7 @@ namespace Tests\Money\Parser;
 use Money\Currencies;
 use Money\Currency;
 use Money\Exception\ParserException;
+use Money\Money;
 use Money\Parser\DecimalMoneyParser;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
@@ -30,6 +31,24 @@ final class DecimalMoneyParserTest extends TestCase
     }
 
     /**
+     * @test
+     */
+    public function it_parses_exponential_number()
+    {
+        $currencies = $this->prophesize(Currencies::class);
+
+        $currencies->subunitFor(Argument::allOf(
+            Argument::type(Currency::class),
+            Argument::which('getCode', 'EUR')
+        ))->willReturn('2');
+
+        $parser = new DecimalMoneyParser($currencies->reveal());
+
+        $value = 2.8865798640254e-15;
+        $this->assertInstanceOf(Money::class, $parser->parse((string)$value, new Currency('EUR')));
+    }
+
+    /**
      * @dataProvider invalidMoneyExamples
      * @test
      */
@@ -51,7 +70,8 @@ final class DecimalMoneyParserTest extends TestCase
 
     /**
      * @group legacy
-     * @expectedDeprecation Passing a currency as string is deprecated since 3.1 and will be removed in 4.0. Please pass a Money\Currency instance instead.
+     * @expectedDeprecation Passing a currency as string is deprecated since 3.1 and will be removed in 4.0. Please
+     *     pass a Money\Currency instance instead.
      * @test
      */
     public function it_accepts_only_a_currency_object()


### PR DESCRIPTION
Hello there....

I have an API that returns executes a reports, does some calculations and returns a result. One of these results happened to be an amount that was a very very tiny one. `2.8865798640254e-15`

My code that consumes the API parses this value to a Money object automatically by doing:

```
$money = $parser->parse((string)$amount, $currency);
```

I know that there is no actual currency that could represent a so tiny amount and it is actually zero (maybe in some bitcoins it have some value).

So the code above throws exception because the value is converted to a string in this form: `2.8865798640254e-15` and this does not pass the expression inside the parser. For now in order to stop getting exception I had to do a quick solution to round the number to 7 decimals and then pass it inside the parser and it feels kinda hackish. 

As a better solution I could create something like a `ExponentialParser` and pass it inside an `AggregateParser` but before going into that I felt that I should ask if you believe that this should be handled by the DecimalParser and not by a different parser... 

If yes maybe I could implement the changes on this PR.

