### PR TITLE
Update docs - "+500" is a valid number format

### DIFF
--- a/doc/getting-started.rst
+++ b/doc/getting-started.rst
@@ -42,7 +42,7 @@ non-supported value is passed a `\InvalidArgumentException` will be thrown.
     // multiple zero's are not accepted
     $fiver = new Money('000', new Currency('USD'));
 
-    // plus sign is not accepted
+    // plus sign is accepted
     $fiver = new Money('+500', new Currency('USD'));
 
 


### PR DESCRIPTION
`Money::USD('+500')` is parsed into Money with no problems, despite the documentation stating otherwise.

Version: `3.1.3`