### PR TITLE
Add php-decimal calculator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ sudo: false
 addons:
     apt_packages:
         - enchant
+        - libmpdec-dev
 
 cache:
     directories:
@@ -18,6 +19,7 @@ php:
     - 7.0
     - 7.1
     - 7.2
+    - 7.3
     - nightly
 
 env:
@@ -45,6 +47,7 @@ install:
     - if [[ "$COMPOSER_FLAGS" == *"--prefer-lowest"* ]]; then travis_retry composer update --prefer-dist --no-interaction --prefer-stable --quiet; fi
     - travis_retry composer update ${COMPOSER_FLAGS} --prefer-dist --no-interaction
     - pip install --user -r doc/requirements.txt
+    - pecl install decimal && echo "extension=decimal.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini || true
 
 script:
     - $TEST_COMMAND

--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,7 @@
         "php-http/mock-client": "^1.0.0"
     },
     "suggest": {
+        "php-decimal": "Calculate without integer limits",
         "ext-bcmath": "Calculate without integer limits",
         "ext-gmp": "Calculate without integer limits",
         "ext-intl": "Format Money objects with intl",

--- a/src/Calculator/DecimalCalculator.php
+++ b/src/Calculator/DecimalCalculator.php
@@ -1,0 +1,218 @@
+<?php
+
+namespace Money\Calculator;
+
+use Decimal\Decimal;
+use Money\Calculator;
+use Money\Money;
+use Money\Number;
+
+/**
+ * @author Rudi Theunissen <rtheunissen@php.net>
+ */
+final class DecimalCalculator implements Calculator
+{
+    /**
+     * @var int
+     */
+    private $scale;
+
+    /**
+     * @var int The maximum number of digits to the left of the decimal point.
+     *          This should be plenty, but can be increased at very little cost.
+     */
+    const MAX_INTEGRAL_DIGITS = 36;
+
+    /**
+     * @var int The number of digits to the right of the decimal point
+     */
+    const DEFAULT_SCALE = 14;
+
+    /**
+     * @var array A partial map of rounding modes
+     */
+    const ROUNDING_MODES = [
+        Money::ROUND_HALF_UP => Decimal::ROUND_HALF_UP,
+        Money::ROUND_HALF_DOWN => Decimal::ROUND_HALF_DOWN,
+        Money::ROUND_HALF_EVEN => Decimal::ROUND_HALF_EVEN,
+        Money::ROUND_UP => Decimal::ROUND_UP,
+        Money::ROUND_DOWN => Decimal::ROUND_DOWN,
+        Money::ROUND_HALF_ODD => Decimal::ROUND_HALF_ODD,
+    ];
+
+    /**
+     * @param int $scale
+     */
+    public function __construct($scale = self::DEFAULT_SCALE)
+    {
+        $this->scale = $scale;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function supported()
+    {
+        return extension_loaded('decimal');
+    }
+
+    /**
+     * Internal helper to centralize conversion to decimal.
+     */
+    private function asDecimal($value)
+    {
+        if (is_float($value)) {
+            $value = number_format($value, $this->scale, '.', '');
+        } else {
+            $value = (string) $value;
+        }
+
+        return new Decimal($value, self::MAX_INTEGRAL_DIGITS + $this->scale);
+    }
+
+    /**
+     * Internal helper to centralize conversion from decimal to string.
+     */
+    private function toString(Decimal $value)
+    {
+        $result = $value->toFixed($this->scale, false, Decimal::ROUND_HALF_UP);
+        $result = rtrim($result, '0');
+        $result = rtrim($result, '.');
+
+        return $result;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function compare($a, $b)
+    {
+        $a = $this->asDecimal($a);
+        $b = $this->asDecimal($b);
+
+        return $a->compareTo($b);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function add($amount, $addend)
+    {
+        return $this->toString($this->asDecimal($amount) + $this->asDecimal($addend));
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @param $amount
+     * @param $subtrahend
+     *
+     * @return string
+     */
+    public function subtract($amount, $subtrahend)
+    {
+        return $this->toString($this->asDecimal($amount) - $this->asDecimal($subtrahend));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function multiply($amount, $multiplier)
+    {
+        return $this->toString($this->asDecimal($amount) * $this->asDecimal($multiplier));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function divide($amount, $divisor)
+    {
+        return $this->toString($this->asDecimal($amount) / $this->asDecimal($divisor));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function share($amount, $ratio, $total)
+    {
+        $decimal = $this->asDecimal($amount) * $this->asDecimal($ratio) / $this->asDecimal($total);
+
+        return $this->toString($decimal->floor());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function mod($amount, $divisor)
+    {
+        return $this->toString($this->asDecimal($amount) % $this->asDecimal($divisor));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function ceil($number)
+    {
+        return $this->toString($this->asDecimal($number)->ceil());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function floor($number)
+    {
+        return $this->toString($this->asDecimal($number)->floor());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function absolute($number)
+    {
+        return ltrim($number, '-');
+    }
+
+    /**
+     * @return int The Decimal rounding mode that matches the Money mode
+     */
+    private function getDecimalRoundingMode(Decimal $decimal, $mode)
+    {
+        $modes = self::ROUNDING_MODES;
+
+        if (array_key_exists($mode, $modes)) {
+            return $modes[$mode];
+        }
+
+        if ($mode === Money::ROUND_HALF_POSITIVE_INFINITY) {
+            return $decimal->isNegative()
+                ? Decimal::ROUND_HALF_DOWN
+                : Decimal::ROUND_HALF_UP;
+        }
+
+        if ($mode === Money::ROUND_HALF_NEGATIVE_INFINITY) {
+            return $decimal->isPositive()
+                ? Decimal::ROUND_HALF_DOWN
+                : Decimal::ROUND_HALF_UP;
+        }
+
+        /* This should never happen. */
+        throw new \InvalidArgumentException('Unknown rounding mode');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function round($number, $mode)
+    {
+        $decimal = $this->asDecimal($number);
+
+        if ($decimal->isInteger()) {
+            return $this->toString($decimal);
+        }
+
+        /* Map the rounding mode to Decimal's constants. */
+        $mode = $this->getDecimalRoundingMode($decimal, $mode);
+
+        return $this->toString($decimal->round(0, $mode));
+    }
+}

--- a/src/Money.php
+++ b/src/Money.php
@@ -3,6 +3,7 @@
 namespace Money;
 
 use Money\Calculator\BcMathCalculator;
+use Money\Calculator\DecimalCalculator;
 use Money\Calculator\GmpCalculator;
 use Money\Calculator\PhpCalculator;
 
@@ -52,6 +53,7 @@ final class Money implements \JsonSerializable
      * @var array
      */
     private static $calculators = [
+        DecimalCalculator::class,
         BcMathCalculator::class,
         GmpCalculator::class,
         PhpCalculator::class,

--- a/tests/Calculator/BcMathCalculatorTest.php
+++ b/tests/Calculator/BcMathCalculatorTest.php
@@ -11,6 +11,11 @@ class BcMathCalculatorTest extends CalculatorTestCase
 {
     private $defaultScale;
 
+    protected function supported()
+    {
+        return BcMathCalculator::supported();
+    }
+
     protected function getCalculator()
     {
         return new BcMathCalculator();

--- a/tests/Calculator/CalculatorTestCase.php
+++ b/tests/Calculator/CalculatorTestCase.php
@@ -16,6 +16,20 @@ abstract class CalculatorTestCase extends TestCase
     abstract protected function getCalculator();
 
     /**
+     * @return bool
+     */
+    abstract protected function supported();
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        if (!$this->supported()) {
+            $this->markTestSkipped();
+        }
+    }
+
+    /**
      * @dataProvider additionExamples
      * @test
      */

--- a/tests/Calculator/DecimalCalculatorTest.php
+++ b/tests/Calculator/DecimalCalculatorTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Tests\Money\Calculator;
+
+use Money\Calculator\DecimalCalculator;
+
+/**
+ * @requires extension bcmath
+ */
+class DecimalCalculatorTest extends CalculatorTestCase
+{
+    protected function supported()
+    {
+        return DecimalCalculator::supported();
+    }
+
+    protected function getCalculator()
+    {
+        return new DecimalCalculator();
+    }
+}

--- a/tests/Calculator/GmpCalculatorTest.php
+++ b/tests/Calculator/GmpCalculatorTest.php
@@ -9,6 +9,11 @@ use Money\Calculator\GmpCalculator;
  */
 class GmpCalculatorTest extends CalculatorTestCase
 {
+    protected function supported()
+    {
+        return GmpCalculator::supported();
+    }
+
     protected function getCalculator()
     {
         return new GmpCalculator();

--- a/tests/Calculator/PhpCalculatorTest.php
+++ b/tests/Calculator/PhpCalculatorTest.php
@@ -6,6 +6,11 @@ use Money\Calculator\PhpCalculator;
 
 class PhpCalculatorTest extends CalculatorTestCase
 {
+    protected function supported()
+    {
+        return true;
+    }
+
     protected function getCalculator()
     {
         return new PhpCalculator();


### PR DESCRIPTION
Hi everyone, this patch adds support for the new php decimal extension. 

It's a real shame how the calculators are set up, because it allows `float` to used (thereby opening the door to poor precision) and requires that the return value of each operation be `string`. The decimal extension uses an optimized internal value that is not a string, so the conversion to and from string for every operation adds unnecessary overhead. 

What I'd love to see is a PHP 7 update of this library where input is normalized (`string` or `int`, ideally) before being passed to the calculator, and to not require that the return result of the calculators be string.

This implementation passes the tests though, so it'll have to do for the time being.

Please see http://php-decimal.io for more information.
