### PR TITLE
Altered CurrencyPair to use a Money object rather than a currency+float

### DIFF
--- a/doc/features/currency-conversion.rst
+++ b/doc/features/currency-conversion.rst
@@ -3,7 +3,7 @@ Currency Conversion
 
 To convert a Money instance from one Currency to another, you need the Converter. This class depends on
 Currencies and Exchange. Exchange returns a `CurrencyPair`, which is the combination of the base
-currency, counter currency and the conversion ratio.
+currency and a Money instance indicating the counter currency and conversion ratio.
 
 
 Fixed Exchange
@@ -136,8 +136,9 @@ the OOP notation to define a pair:
 
     use Money\Currency;
     use Money\CurrencyPair;
+    use Money\Money;
 
-    $pair = new CurrencyPair(new Currency('EUR'), new Currency('USD'), 1.2500);
+    $pair = new CurrencyPair(new Currency('EUR'), new Money(1.2500, new Currency('USD')));
 
 
 But you can also parse ISO notations. For example, the quotation ``EUR/USD 1.2500``

--- a/spec/ConverterSpec.php
+++ b/spec/ConverterSpec.php
@@ -26,7 +26,9 @@ final class ConverterSpec extends ObjectBehavior
     {
         $baseCurrency = new Currency($baseCurrencyCode = 'ABC');
         $counterCurrency = new Currency($counterCurrencyCode = 'XYZ');
-        $pair = new CurrencyPair($baseCurrency, $counterCurrency, 0.5);
+        $counterRatioAmount = 0.5;
+        $conversionRatio = new Money($counterRatioAmount, $counterCurrency);
+        $pair = new CurrencyPair($baseCurrency, $conversionRatio);
 
         $currencies->subunitFor($baseCurrency)->willReturn(100);
         $currencies->subunitFor($counterCurrency)->willReturn(100);
@@ -47,7 +49,8 @@ final class ConverterSpec extends ObjectBehavior
     {
         $baseCurrency = new Currency('EUR');
         $counterCurrency = new Currency('USD');
-        $pair = new CurrencyPair($baseCurrency, $counterCurrency, 1.25);
+        $conversionRatio = new Money(1.25, $counterCurrency);
+        $pair = new CurrencyPair($baseCurrency, $conversionRatio);
 
         $currencies->subunitFor($baseCurrency)->willReturn(2);
         $currencies->subunitFor($counterCurrency)->willReturn(2);

--- a/spec/CurrencyPairSpec.php
+++ b/spec/CurrencyPairSpec.php
@@ -4,13 +4,14 @@ namespace spec\Money;
 
 use Money\Currency;
 use Money\CurrencyPair;
+use Money\Money;
 use PhpSpec\ObjectBehavior;
 
 final class CurrencyPairSpec extends ObjectBehavior
 {
     function let()
     {
-        $this->beConstructedWith(new Currency('EUR'), new Currency('USD'), 1.250000);
+        $this->beConstructedWith(new Currency('EUR'), new Money(1.250000, new Currency('USD')));
     }
 
     function it_is_initializable()
@@ -25,11 +26,11 @@ final class CurrencyPairSpec extends ObjectBehavior
 
     function it_has_currencies_and_ratio()
     {
-        $this->beConstructedWith($base = new Currency('EUR'), $counter = new Currency('USD'), $ratio = 1.0);
+        $this->beConstructedWith($baseCurrency = new Currency('EUR'), $counterRatio = new Money($ratioAmount = 1.0, $counterCurrency = new Currency('USD')));
 
-        $this->getBaseCurrency()->shouldReturn($base);
-        $this->getCounterCurrency()->shouldReturn($counter);
-        $this->getConversionRatio()->shouldReturn($ratio);
+        $this->getBaseCurrency()->shouldReturn($baseCurrency);
+        $this->getCounterCurrency()->shouldReturn($counterCurrency);
+        $this->getConversionRatio()->shouldReturn($counterRatio);
     }
 
     function it_throws_an_exception_when_ratio_is_not_numeric()
@@ -41,10 +42,10 @@ final class CurrencyPairSpec extends ObjectBehavior
 
     function it_equals_to_another_currency_pair()
     {
-        $this->equals(new CurrencyPair(new Currency('GBP'), new Currency('USD'), 1.250000))->shouldReturn(false);
-        $this->equals(new CurrencyPair(new Currency('EUR'), new Currency('GBP'), 1.250000))->shouldReturn(false);
-        $this->equals(new CurrencyPair(new Currency('EUR'), new Currency('USD'), 1.5000))->shouldReturn(false);
-        $this->equals(new CurrencyPair(new Currency('EUR'), new Currency('USD'), 1.250000))->shouldReturn(true);
+        $this->equals(new CurrencyPair(new Currency('GBP'), new Money(1.250000, new Currency('USD'))))->shouldReturn(false);
+        $this->equals(new CurrencyPair(new Currency('EUR'), new Money(1.250000, new Currency('GBP'))))->shouldReturn(false);
+        $this->equals(new CurrencyPair(new Currency('EUR'), new Money(1.5000, new Currency('USD'))))->shouldReturn(false);
+        $this->equals(new CurrencyPair(new Currency('EUR'), new Money(1.250000, new Currency('USD'))))->shouldReturn(true);
     }
 
     function it_parses_an_iso_string()

--- a/spec/Exchange/ExchangerExchangeSpec.php
+++ b/spec/Exchange/ExchangerExchangeSpec.php
@@ -13,6 +13,7 @@ use Money\Exception\UnresolvableCurrencyPairException;
 use Money\Exchange;
 use Money\Exchange\ExchangerExchange;
 use Money\Exchange\SwapExchange;
+use Money\Money;
 use Swap\Swap;
 use PhpSpec\ObjectBehavior;
 
@@ -45,7 +46,7 @@ final class ExchangerExchangeSpec extends ObjectBehavior
         $currencyPair->shouldHaveType(CurrencyPair::class);
         $currencyPair->getBaseCurrency()->shouldReturn($base);
         $currencyPair->getCounterCurrency()->shouldReturn($counter);
-        $currencyPair->getConversionRatio()->shouldReturn(1.0);
+        $currencyPair->getConversionRatio()->shouldReturn(new Money(1.0, $counter));
     }
 
     function it_throws_an_exception_when_cannot_exchange_currencies(Exchanger $exchanger)

--- a/spec/Exchange/FixedExchangeSpec.php
+++ b/spec/Exchange/FixedExchangeSpec.php
@@ -7,6 +7,7 @@ use Money\CurrencyPair;
 use Money\Exception\UnresolvableCurrencyPairException;
 use Money\Exchange;
 use Money\Exchange\FixedExchange;
+use Money\Money;
 use PhpSpec\ObjectBehavior;
 
 final class FixedExchangeSpec extends ObjectBehavior
@@ -39,8 +40,7 @@ final class FixedExchangeSpec extends ObjectBehavior
 
         $currencyPair->shouldHaveType(CurrencyPair::class);
         $currencyPair->getBaseCurrency()->shouldReturn($baseCurrency);
-        $currencyPair->getCounterCurrency()->shouldReturn($counterCurrency);
-        $currencyPair->getConversionRatio()->shouldReturn(1.25);
+        $currencyPair->getConversionRatio()->shouldReturn(new Money(1.25, $counterCurrency));
     }
 
     function it_cannot_exchange_currencies()

--- a/spec/Exchange/ReversedCurrenciesExchangeSpec.php
+++ b/spec/Exchange/ReversedCurrenciesExchangeSpec.php
@@ -7,6 +7,7 @@ use Money\CurrencyPair;
 use Money\Exception\UnresolvableCurrencyPairException;
 use Money\Exchange;
 use Money\Exchange\ReversedCurrenciesExchange;
+use Money\Money;
 use PhpSpec\ObjectBehavior;
 
 final class ReversedCurrenciesExchangeSpec extends ObjectBehavior
@@ -30,7 +31,7 @@ final class ReversedCurrenciesExchangeSpec extends ObjectBehavior
     {
         $baseCurrency = new Currency('EUR');
         $counterCurrency = new Currency('USD');
-        $currencyPair = new CurrencyPair($baseCurrency, $counterCurrency, 1.25);
+        $currencyPair = new CurrencyPair($baseCurrency, new Money(1.25, $counterCurrency));
 
         $exchange->quote($baseCurrency, $counterCurrency)->willReturn($currencyPair);
 
@@ -41,8 +42,8 @@ final class ReversedCurrenciesExchangeSpec extends ObjectBehavior
     {
         $baseCurrency = new Currency('USD');
         $counterCurrency = new Currency('EUR');
-        $conversionRatio = 1.25;
-        $currencyPair = new CurrencyPair($counterCurrency, $baseCurrency, $conversionRatio);
+        $conversionRatioAmount = 1.25;
+        $currencyPair = new CurrencyPair($counterCurrency, new Money($conversionRatioAmount, $baseCurrency));
 
         $exchange->quote($baseCurrency, $counterCurrency)->willThrow(UnresolvableCurrencyPairException::class);
         $exchange->quote($counterCurrency, $baseCurrency)->willReturn($currencyPair);
@@ -52,7 +53,7 @@ final class ReversedCurrenciesExchangeSpec extends ObjectBehavior
         $currencyPair->shouldHaveType(CurrencyPair::class);
         $currencyPair->getBaseCurrency()->shouldReturn($baseCurrency);
         $currencyPair->getCounterCurrency()->shouldReturn($counterCurrency);
-        $currencyPair->getConversionRatio()->shouldReturn(1 / $conversionRatio);
+        $currencyPair->getConversionRatio()->getAmount()->shouldReturn(1 / $conversionRatio);
     }
 
     function it_throws_an_exception_when_neither_the_original_nor_the_reversed_currency_pair_can_be_resolved(Exchange $exchange)

--- a/spec/Exchange/SwapExchangeSpec.php
+++ b/spec/Exchange/SwapExchangeSpec.php
@@ -9,6 +9,7 @@ use Money\CurrencyPair;
 use Money\Exception\UnresolvableCurrencyPairException;
 use Money\Exchange;
 use Money\Exchange\SwapExchange;
+use Money\Money;
 use Swap\Swap;
 use PhpSpec\ObjectBehavior;
 
@@ -40,7 +41,7 @@ final class SwapExchangeSpec extends ObjectBehavior
         $currencyPair->shouldHaveType(CurrencyPair::class);
         $currencyPair->getBaseCurrency()->shouldReturn($base);
         $currencyPair->getCounterCurrency()->shouldReturn($counter);
-        $currencyPair->getConversionRatio()->shouldReturn(1.0);
+        $currencyPair->getConversionRatio()->shouldReturn(new Money(1.0, $counter));
     }
 
     function it_throws_an_exception_when_cannot_exchange_currencies(Swap $swap)

--- a/src/CurrencyPair.php
+++ b/src/CurrencyPair.php
@@ -19,33 +19,26 @@ final class CurrencyPair implements \JsonSerializable
     private $baseCurrency;
 
     /**
-     * Currency to convert to.
+     * Money $baseCurrency converts to in the counter currency.
      *
-     * @var Currency
-     */
-    private $counterCurrency;
-
-    /**
-     * @var float
+     * @var Money
      */
     private $conversionRatio;
 
     /**
      * @param Currency $baseCurrency
-     * @param Currency $counterCurrency
-     * @param float    $conversionRatio
+     * @param Money    $conversionRatio
      *
-     * @throws \InvalidArgumentException If conversion ratio is not numeric
+     * @throws \InvalidArgumentException If conversion conversionRatio is null
      */
-    public function __construct(Currency $baseCurrency, Currency $counterCurrency, $conversionRatio)
+    public function __construct(Currency $baseCurrency, Money $conversionRatio)
     {
-        if (!is_numeric($conversionRatio)) {
-            throw new \InvalidArgumentException('Conversion ratio must be numeric');
+        if (is_null($conversionRatio)) {
+            throw new \InvalidArgumentException('Conversion conversionRatio must not be null');
         }
 
         $this->counterCurrency = $counterCurrency;
-        $this->baseCurrency = $baseCurrency;
-        $this->conversionRatio = (float) $conversionRatio;
+        $this->conversionRatio = $conversionRatio;
     }
 
     /**
@@ -74,7 +67,17 @@ final class CurrencyPair implements \JsonSerializable
             );
         }
 
-        return new self(new Currency($matches[1]), new Currency($matches[2]), $matches[3]);
+        return new self(new Currency($matches[1]), new Money($matches[3], $matches[2]));
+    }
+
+    /**
+     * Returns the Money $baseCurrency converts to in the counter currency.
+     *
+     * @return Money
+     */
+    public function getConversionRatio()
+    {
+        return $this->conversionRatio;
     }
 
     /**
@@ -84,7 +87,7 @@ final class CurrencyPair implements \JsonSerializable
      */
     public function getCounterCurrency()
     {
-        return $this->counterCurrency;
+        return $this->conversionRatio->getCurrency();
     }
 
     /**
@@ -98,16 +101,6 @@ final class CurrencyPair implements \JsonSerializable
     }
 
     /**
-     * Returns the conversion ratio.
-     *
-     * @return float
-     */
-    public function getConversionRatio()
-    {
-        return $this->conversionRatio;
-    }
-
-    /**
      * Checks if an other CurrencyPair has the same parameters as this.
      *
      * @param CurrencyPair $other
@@ -118,8 +111,7 @@ final class CurrencyPair implements \JsonSerializable
     {
         return
             $this->baseCurrency->equals($other->baseCurrency)
-            && $this->counterCurrency->equals($other->counterCurrency)
-            && $this->conversionRatio === $other->conversionRatio
+            && $this->conversionRatio->equals($other->conversionRatio)
         ;
     }
 
@@ -132,8 +124,8 @@ final class CurrencyPair implements \JsonSerializable
     {
         return [
             'baseCurrency' => $this->baseCurrency,
-            'counterCurrency' => $this->counterCurrency,
-            'ratio' => $this->conversionRatio,
+            'counterCurrency' => $this->conversionRatio->getCurrency(),
+            'ratio' => $this->conversionRatio->getAmount(),
         ];
     }
 }

--- a/src/Exchange/ExchangerExchange.php
+++ b/src/Exchange/ExchangerExchange.php
@@ -10,6 +10,7 @@ use Money\Currency;
 use Money\CurrencyPair;
 use Money\Exception\UnresolvableCurrencyPairException;
 use Money\Exchange;
+use Money\Money;
 
 /**
  * Provides a way to get exchange rate from a third-party source and return a currency pair.
@@ -45,6 +46,6 @@ final class ExchangerExchange implements Exchange
             throw UnresolvableCurrencyPairException::createFromCurrencies($baseCurrency, $counterCurrency);
         }
 
-        return new CurrencyPair($baseCurrency, $counterCurrency, $rate->getValue());
+        return new CurrencyPair($baseCurrency, new Money($rate->getValue(), $counterCurrency));
     }
 }

--- a/src/Exchange/FixedExchange.php
+++ b/src/Exchange/FixedExchange.php
@@ -6,6 +6,7 @@ use Money\Currency;
 use Money\CurrencyPair;
 use Money\Exception\UnresolvableCurrencyPairException;
 use Money\Exchange;
+use Money\Money;
 
 /**
  * Provides a way to get exchange rate from a static list (array).
@@ -35,8 +36,10 @@ final class FixedExchange implements Exchange
         if (isset($this->list[$baseCurrency->getCode()][$counterCurrency->getCode()])) {
             return new CurrencyPair(
                 $baseCurrency,
-                $counterCurrency,
-                $this->list[$baseCurrency->getCode()][$counterCurrency->getCode()]
+                new Money(
+                    $this->list[$baseCurrency->getCode()][$counterCurrency->getCode()],
+                    $counterCurrency
+                )
             );
         }
 

--- a/src/Exchange/IndirectExchange.php
+++ b/src/Exchange/IndirectExchange.php
@@ -74,7 +74,7 @@ final class IndirectExchange implements Exchange
             return $this->exchange->quote($baseCurrency, $counterCurrency);
         } catch (UnresolvableCurrencyPairException $exception) {
             $rate = array_reduce($this->getConversions($baseCurrency, $counterCurrency), function ($carry, CurrencyPair $pair) {
-                return static::getCalculator()->multiply($carry, $pair->getConversionRatio());
+                return static::getCalculator()->multiply($carry, $pair->getConversionRatio()->getAmount());
             }, '1.0');
 
             return new CurrencyPair($baseCurrency, $counterCurrency, $rate);

--- a/src/Exchange/ReversedCurrenciesExchange.php
+++ b/src/Exchange/ReversedCurrenciesExchange.php
@@ -6,6 +6,7 @@ use Money\Currency;
 use Money\CurrencyPair;
 use Money\Exception\UnresolvableCurrencyPairException;
 use Money\Exchange;
+use Money\Money;
 
 /**
  * Tries the reverse of the currency pair if one is not available.
@@ -40,7 +41,7 @@ final class ReversedCurrenciesExchange implements Exchange
             try {
                 $currencyPair = $this->exchange->quote($counterCurrency, $baseCurrency);
 
-                return new CurrencyPair($baseCurrency, $counterCurrency, 1 / $currencyPair->getConversionRatio());
+                return new CurrencyPair($baseCurrency, new Money(1 / $currencyPair->getConversionRatio(), $counterCurrency));
             } catch (UnresolvableCurrencyPairException $inversedException) {
                 throw $exception;
             }

--- a/src/Exchange/SwapExchange.php
+++ b/src/Exchange/SwapExchange.php
@@ -7,6 +7,7 @@ use Money\Currency;
 use Money\CurrencyPair;
 use Money\Exception\UnresolvableCurrencyPairException;
 use Money\Exchange;
+use Money\Money;
 use Swap\Swap;
 
 /**
@@ -40,6 +41,6 @@ final class SwapExchange implements Exchange
             throw UnresolvableCurrencyPairException::createFromCurrencies($baseCurrency, $counterCurrency);
         }
 
-        return new CurrencyPair($baseCurrency, $counterCurrency, $rate->getValue());
+        return new CurrencyPair($baseCurrency, new Money($rate->getValue(), $counterCurrency));
     }
 }

--- a/tests/ConverterTest.php
+++ b/tests/ConverterTest.php
@@ -28,7 +28,8 @@ final class ConverterTest extends TestCase
     ) {
         $baseCurrency = new Currency($baseCurrencyCode);
         $counterCurrency = new Currency($counterCurrencyCode);
-        $pair = new CurrencyPair($baseCurrency, $counterCurrency, $ratio);
+        $conversionRatio = new Money($ratio, $counterCurrency);
+        $pair = new CurrencyPair($baseCurrency, $conversionRatio);
 
         /** @var Currencies|ObjectProphecy $currencies */
         $currencies = $this->prophesize(Currencies::class);

--- a/tests/CurrencyPairTest.php
+++ b/tests/CurrencyPairTest.php
@@ -4,6 +4,7 @@ namespace Tests\Money;
 
 use Money\Currency;
 use Money\CurrencyPair;
+use Money\Money;
 use PHPUnit\Framework\TestCase;
 
 final class CurrencyPairTest extends TestCase
@@ -14,7 +15,7 @@ final class CurrencyPairTest extends TestCase
     public function it_converts_to_json()
     {
         $expectedJson = '{"baseCurrency":"EUR","counterCurrency":"USD","ratio":1.25}';
-        $actualJson = json_encode(new CurrencyPair(new Currency('EUR'), new Currency('USD'), 1.25));
+        $actualJson = json_encode(new CurrencyPair(new Currency('EUR'), new Money(1.25, new Currency('USD'))));
 
         $this->assertEquals($expectedJson, $actualJson);
     }


### PR DESCRIPTION
This needs some fixes but I was hoping it could serve as a suggestion/starting-point.

I Changed CurrencyPair to use a Money object rather than a currency/ratio pair. This way the ratio is treated as a big integer rather than a float.

So for instance, a CurrencyPair would be created as

```
$baseCurrency = new Currency('USD');
$counterCurrency = new Currency('CAD');
$conversionRatio = new Money(12943, $counterCurrency);

$pair = new CurrencyPair($baseCurrency, $conversionRatio);
```
I think this makes sense since the ratio really is Money (the amount of a currency for 1.0 units of another currency) and the value is most likely going to be multiplied against Money objects.

To get it working, several of the static values I changed would have to be changed to ints/strings rather than floats. Some code would need to be added to handle conversion from iso X.XXXX values to integers/strings.