### PR TITLE
Deprecate initializing currency with an empty string

### DIFF
--- a/src/Currency.php
+++ b/src/Currency.php
@@ -27,7 +27,7 @@ final class Currency implements \JsonSerializable
             throw new \InvalidArgumentException('Currency code should be string');
         }
 
-        if ($code === ''){
+        if ($code === '') {
             @trigger_error('Passing an empty string as currency since 3.1 and will not be supported in 4.0.', E_USER_DEPRECATED);
         }
 

--- a/src/Currency.php
+++ b/src/Currency.php
@@ -27,6 +27,10 @@ final class Currency implements \JsonSerializable
             throw new \InvalidArgumentException('Currency code should be string');
         }
 
+        if ($code === ''){
+            @trigger_error('Passing an empty string as currency since 3.1 and will not be supported in 4.0.', E_USER_DEPRECATED);
+        }
+
         $this->code = $code;
     }
 

--- a/src/Currency.php
+++ b/src/Currency.php
@@ -28,7 +28,7 @@ final class Currency implements \JsonSerializable
         }
 
         if ($code === '') {
-            @trigger_error('Passing an empty string as currency since 3.1 and will not be supported in 4.0.', E_USER_DEPRECATED);
+            throw new \InvalidArgumentException('Currency code should not be empty string');
         }
 
         $this->code = $code;

--- a/tests/Currencies/CurrencyListTest.php
+++ b/tests/Currencies/CurrencyListTest.php
@@ -62,16 +62,6 @@ final class CurrencyListTest extends TestCase
     }
 
     /**
-     * @test
-     */
-    public function it_does_not_have_blank_currency()
-    {
-        $currencies = new CurrencyList(self::$correctCurrencies);
-
-        $this->assertFalse($currencies->contains(new Currency('')));
-    }
-
-    /**
      * @dataProvider invalidInstantiation
      * @test
      */

--- a/tests/Currencies/ISOCurrenciesTest.php
+++ b/tests/Currencies/ISOCurrenciesTest.php
@@ -78,16 +78,6 @@ final class ISOCurrenciesTest extends TestCase
         $this->assertContainsOnlyInstancesOf(Currency::class, $iterator);
     }
 
-    /**
-     * @test
-     */
-    public function it_does_not_have_blank_currency()
-    {
-        $currencies = new ISOCurrencies();
-
-        $this->assertFalse($currencies->contains(new Currency('')));
-    }
-
     public function currencyCodeExamples()
     {
         $currencies = require __DIR__.'/../../resources/currency.php';


### PR DESCRIPTION
Should it be allowed to initialize an empty currency?