### PR TITLE
Documentation of plus sign usage

### DIFF
--- a/doc/getting-started.rst
+++ b/doc/getting-started.rst
@@ -42,9 +42,6 @@ non-supported value is passed a `\InvalidArgumentException` will be thrown.
     // multiple zero's are not accepted
     $fiver = new Money('000', new Currency('USD'));
 
-    // plus sign is not accepted
-    $fiver = new Money('+500', new Currency('USD'));
-
 
 
 Installation

--- a/spec/MoneySpec.php
+++ b/spec/MoneySpec.php
@@ -70,6 +70,13 @@ final class MoneySpec extends ObjectBehavior
         $this->beConstructedWith('5.00', new Currency(self::CURRENCY));
     }
 
+    function it_constructs_integer_with_plus()
+    {
+        $this->beConstructedWith('+500', new Currency(self::CURRENCY));
+
+        $this->shouldNotThrow(\InvalidArgumentException::class)->duringInstantiation();
+    }
+
     function it_tests_currency_equality()
     {
         $this->isSameCurrency(new Money(self::AMOUNT, new Currency(self::CURRENCY)))->shouldReturn(true);


### PR DESCRIPTION
- add test that plus sign is supported
- remove documentation since it does not belong there
- replaces #513 

The reason that it is supported is that is allowed by `FILTER_VALIDATE_INT` in PHP itself.