### PR TITLE
Add Dockerfile to export ignore

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,7 @@
 .editorconfig     export-ignore
 .gitattributes    export-ignore
 .gitignore        export-ignore
+Dockerfile        export-ignore
 /.flintci.yml     export-ignore
 /.github/         export-ignore
 /.php_cs.dist     export-ignore


### PR DESCRIPTION
The dockerfile is only needed for developers of the library not for this who use the library