### PR TITLE
Allow numeric code

### DIFF
--- a/src/Currencies/ISOCurrencies.php
+++ b/src/Currencies/ISOCurrencies.php
@@ -30,6 +30,7 @@ final class ISOCurrencies implements Currencies
 
     /**
      * @param string $code
+     *
      * @return array|null
      */
     private function findCurrencyByCode($code)

--- a/src/Currencies/ISOCurrencies.php
+++ b/src/Currencies/ISOCurrencies.php
@@ -25,7 +25,23 @@ final class ISOCurrencies implements Currencies
      */
     public function contains(Currency $currency)
     {
-        return isset($this->getCurrencies()[$currency->getCode()]);
+        return $this->findCurrencyByCode($currency->getCode()) !== null;
+    }
+
+    /**
+     * @param string $code
+     * @return array|null
+     */
+    private function findCurrencyByCode($code)
+    {
+        foreach ($this->getCurrencies() as $currency) {
+            if (0 === strcasecmp($code, $currency['alphabeticCode']) ||
+                0 === strcasecmp($code, $currency['numericCode'])) {
+                return $currency;
+            }
+        }
+
+        return null;
     }
 
     /**
@@ -33,11 +49,13 @@ final class ISOCurrencies implements Currencies
      */
     public function subunitFor(Currency $currency)
     {
-        if (!$this->contains($currency)) {
+        $isoCurrency = $this->findCurrencyByCode($currency->getCode());
+
+        if (!$isoCurrency) {
             throw new UnknownCurrencyException('Cannot find ISO currency '.$currency->getCode());
         }
 
-        return $this->getCurrencies()[$currency->getCode()]['minorUnit'];
+        return $isoCurrency['minorUnit'];
     }
 
     /**
@@ -51,11 +69,13 @@ final class ISOCurrencies implements Currencies
      */
     public function numericCodeFor(Currency $currency)
     {
-        if (!$this->contains($currency)) {
+        $isoCurrency = $this->findCurrencyByCode($currency->getCode());
+
+        if (!$isoCurrency) {
             throw new UnknownCurrencyException('Cannot find ISO currency '.$currency->getCode());
         }
 
-        return $this->getCurrencies()[$currency->getCode()]['numericCode'];
+        return $isoCurrency['numericCode'];
     }
 
     /**

--- a/tests/Currencies/ISOCurrenciesTest.php
+++ b/tests/Currencies/ISOCurrenciesTest.php
@@ -96,7 +96,7 @@ final class ISOCurrenciesTest extends TestCase
         $currencies = require __DIR__.'/../../resources/currency.php';
 
         return array_map(function ($currency) {
-            return [(string)$currency['numericCode']];
+            return [(string) $currency['numericCode']];
         }, $currencies);
     }
 }

--- a/tests/Currencies/ISOCurrenciesTest.php
+++ b/tests/Currencies/ISOCurrenciesTest.php
@@ -10,7 +10,8 @@ use PHPUnit\Framework\TestCase;
 final class ISOCurrenciesTest extends TestCase
 {
     /**
-     * @dataProvider currencyCodeExamples
+     * @dataProvider alphabeticCurrencyCodeExamples
+     * @dataProvider numericCurrencyCodeExamples
      * @test
      */
     public function it_has_iso_currencies($currency)
@@ -21,7 +22,8 @@ final class ISOCurrenciesTest extends TestCase
     }
 
     /**
-     * @dataProvider currencyCodeExamples
+     * @dataProvider alphabeticCurrencyCodeExamples
+     * @dataProvider numericCurrencyCodeExamples
      * @test
      */
     public function it_provides_subunit($currency)
@@ -44,7 +46,8 @@ final class ISOCurrenciesTest extends TestCase
     }
 
     /**
-     * @dataProvider currencyCodeExamples
+     * @dataProvider alphabeticCurrencyCodeExamples
+     * @dataProvider numericCurrencyCodeExamples
      * @test
      */
     public function it_provides_numeric_code($currency)
@@ -57,7 +60,7 @@ final class ISOCurrenciesTest extends TestCase
     /**
      * @test
      */
-    public function it_throws_an_exception_when_providing_numeric_code_and_currency_is_unknown()
+    public function it_throws_an_exception_when_providing_and_currency_is_unknown()
     {
         $this->expectException(UnknownCurrencyException::class);
 
@@ -78,13 +81,22 @@ final class ISOCurrenciesTest extends TestCase
         $this->assertContainsOnlyInstancesOf(Currency::class, $iterator);
     }
 
-    public function currencyCodeExamples()
+    public function alphabeticCurrencyCodeExamples()
     {
         $currencies = require __DIR__.'/../../resources/currency.php';
         $currencies = array_keys($currencies);
 
         return array_map(function ($currency) {
             return [$currency];
+        }, $currencies);
+    }
+
+    public function numericCurrencyCodeExamples()
+    {
+        $currencies = require __DIR__.'/../../resources/currency.php';
+
+        return array_map(function ($currency) {
+            return [(string)$currency['numericCode']];
         }, $currencies);
     }
 }


### PR DESCRIPTION
This is one way of doing it, an alternative would be providing new "Currencies" class that can handle both and deprecating this one, but since this is not a BC Break I don't think that is needed.