### PR TITLE
Standard PHP formatter overrides fractions

### DIFF
--- a/src/Formatter/IntlMoneyFormatter.php
+++ b/src/Formatter/IntlMoneyFormatter.php
@@ -64,6 +64,13 @@ final class IntlMoneyFormatter implements MoneyFormatter
             $formatted = '-'.$formatted;
         }
 
-        return $this->formatter->formatCurrency($formatted, $money->getCurrency()->getCode());
+        $factionDigests = $this->formatter->getAttribute(\NumberFormatter::FRACTION_DIGITS);
+        $this->formatter->setAttribute(\NumberFormatter::FRACTION_DIGITS, $subunit);
+
+        $result = $this->formatter->formatCurrency($formatted, $money->getCurrency()->getCode());
+
+        $this->formatter->setAttribute(\NumberFormatter::FRACTION_DIGITS, $factionDigests);
+
+        return $result;
     }
 }


### PR DESCRIPTION
The Standard PHP formatter overrides the fractions when using a currency object that has different fractions that what is defined in the icu lib on the operating system.

Therefore the `IntlMoneyFormatter` should use the same fraction for the PHP number formatter call as it has detected before.