### PR TITLE
[DOCS] Updates parsing example in docs

### DIFF
--- a/doc/features/parsing.rst
+++ b/doc/features/parsing.rst
@@ -73,6 +73,7 @@ provide the correct subunit for the specific currency, you should provide the sp
 
 .. code-block:: php
 
+    use Money\Currency;
     use Money\Currencies\ISOCurrencies;
     use Money\Parser\DecimalMoneyParser;
 
@@ -80,7 +81,7 @@ provide the correct subunit for the specific currency, you should provide the sp
 
     $moneyParser = new DecimalMoneyParser($currencies);
 
-    $money = $moneyParser->parse('1000', 'USD');
+    $money = $moneyParser->parse('1000', new Currency('USD'));
 
     echo $money->getAmount(); // outputs 100000
 


### PR DESCRIPTION
As #543 added deprecation warnings for passing currency as a `string` in the `parse` method of current Parsers, it makes sense that the docs use the recommended way of passing currency to the `parse` method.

Thanks for amazing package!