### PR TITLE
Added types for `Money` to be understood as pure/immutable downstream

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -11,7 +11,9 @@ Dockerfile        export-ignore
 /phpspec.ci.yml   export-ignore
 /phpspec.yml.dist export-ignore
 /phpunit.xml.dist export-ignore
+/psalm.xml        export-ignore
 /spec/            export-ignore
+/static-analysis/ export-ignore
 /tests/           export-ignore
 
 /doc/               export-ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,33 @@ jobs:
       - name: Run tests
         run: composer test
 
+  static-analysis:
+    name: Static Analysis
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php: ['7.3']
+
+    steps:
+      - name: Set up PHP
+        uses: shivammathur/setup-php@1.3.6
+        with:
+          php-version: ${{ matrix.php }}
+          extension-csv: bcmath, gmp, intl, dom, mbstring
+
+      - name: Checkout code
+        uses: actions/checkout@v1
+
+      - name: Download dependencies
+        run: composer update --prefer-stable --prefer-lowest --prefer-dist --no-interaction
+
+      - name: Download Psalm
+        run: |
+          wget https://github.com/vimeo/psalm/releases/download/3.7.1/psalm.phar
+
+      - name: Run Static Analysis
+        run: php psalm.phar
+
   docs:
     name: Docs
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .php_cs
 .php_cs.cache
+psalm.phar
 /build/
 /composer.lock
 /phpspec.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,11 +37,6 @@ matrix:
     include:
         - php: 5.6
           env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest" COVERAGE=true TEST_COMMAND="composer test-coverage"
-        - php: 7.3
-          before_script:
-              - wget https://github.com/vimeo/psalm/releases/download/3.7.1/psalm.phar
-              - chmod +x psalm.phar
-          script: psalm.phar
 
 before_install:
     - if [[ $COVERAGE != true ]]; then phpenv config-rm xdebug.ini || true; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,11 @@ matrix:
     include:
         - php: 5.6
           env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest" COVERAGE=true TEST_COMMAND="composer test-coverage"
+        - php: 7.3
+          before_script:
+              - wget https://github.com/vimeo/psalm/releases/download/3.7.1/psalm.phar
+              - chmod +x psalm.phar
+          script: psalm.phar
 
 before_install:
     - if [[ $COVERAGE != true ]]; then phpenv config-rm xdebug.ini || true; fi

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0"?>
+<psalm
+    totallyTyped="true"
+    resolveFromConfigFile="true"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://getpsalm.org/schema/config"
+    xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+>
+    <projectFiles>
+        <directory name="static-analysis" />
+    </projectFiles>
+
+    <!--
+    <issueHandlers>
+        <LessSpecificReturnType errorLevel="error" />
+        <DeprecatedMethod errorLevel="error" />
+        <DeprecatedProperty errorLevel="error" />
+        <DeprecatedClass errorLevel="error" />
+        <DeprecatedConstant errorLevel="error" />
+        <DeprecatedFunction errorLevel="error" />
+        <DeprecatedInterface errorLevel="error" />
+        <DeprecatedTrait errorLevel="error" />
+
+        <InternalMethod errorLevel="error" />
+        <InternalProperty errorLevel="error" />
+        <InternalClass errorLevel="error" />
+
+        <MissingClosureReturnType errorLevel="error" />
+        <MissingReturnType errorLevel="error" />
+        <MissingPropertyType errorLevel="error" />
+        <InvalidDocblock errorLevel="error" />
+        <MisplacedRequiredParam errorLevel="error" />
+
+        <PropertyNotSetInConstructor errorLevel="error" />
+        <MissingConstructor errorLevel="error" />
+        <MissingClosureParamType errorLevel="error" />
+        <MissingParamType errorLevel="error" />
+
+        <RedundantCondition errorLevel="error" />
+
+        <DocblockTypeContradiction errorLevel="error" />
+        <RedundantConditionGivenDocblockType errorLevel="error" />
+
+        <UnresolvableInclude errorLevel="error" />
+
+        <RawObjectIteration errorLevel="error" />
+
+        <InvalidStringClass errorLevel="error" />
+    </issueHandlers>
+    -->
+</psalm>

--- a/src/Currency.php
+++ b/src/Currency.php
@@ -8,6 +8,8 @@ namespace Money;
  * Holds Currency specific data.
  *
  * @author Mathias Verraes
+ *
+ * @psalm-immutable
  */
 final class Currency implements \JsonSerializable
 {

--- a/src/Money.php
+++ b/src/Money.php
@@ -10,6 +10,8 @@ use Money\Calculator\PhpCalculator;
  * Money Value Object.
  *
  * @author Mathias Verraes
+ *
+ * @psalm-immutable
  */
 final class Money implements \JsonSerializable
 {
@@ -239,6 +241,8 @@ final class Money implements \JsonSerializable
      * @param Money[] $subtrahends
      *
      * @return Money
+     *
+     * @psalm-pure
      */
     public function subtract(Money ...$subtrahends)
     {
@@ -527,6 +531,8 @@ final class Money implements \JsonSerializable
      * @param Money ...$collection
      *
      * @return Money
+     *
+     * @psalm-pure
      */
     public static function min(self $first, self ...$collection)
     {
@@ -546,6 +552,8 @@ final class Money implements \JsonSerializable
      * @param Money ...$collection
      *
      * @return Money
+     *
+     * @psalm-pure
      */
     public static function max(self $first, self ...$collection)
     {
@@ -565,6 +573,8 @@ final class Money implements \JsonSerializable
      * @param Money ...$collection
      *
      * @return Money
+     *
+     * @psalm-pure
      */
     public static function sum(self $first, self ...$collection)
     {
@@ -576,6 +586,8 @@ final class Money implements \JsonSerializable
      * @param Money ...$collection
      *
      * @return Money
+     *
+     * @psalm-pure
      */
     public static function avg(self $first, self ...$collection)
     {

--- a/static-analysis/money-is-pure.php
+++ b/static-analysis/money-is-pure.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Tests\MoneyStaticAnalysis;
+
+use Money\Currency;
+use Money\Money;
+
+/** @psalm-pure */
+function consumeMoney(Money $money): Money
+{
+    return Money::avg(
+        new Money(100, new Currency('USD')),
+        Money::max(
+            new Money(1, new Currency('USD')),
+            Money::min(
+                new Money(10000, new Currency('USD')),
+                Money::sum(new Money(123, new Currency('USD')), $money)
+                    ->subtract(new Money(456, new Currency('USD')))
+            )
+        )
+    );
+}


### PR DESCRIPTION
Note: this does *NOT* make `Money` per-se pass any sort of internal static analysis, but only declares a thin contract between consumers of `Money` and its public API, allowing downstream to rely on the immutable invariants of the implementation provided thus far.

Adding further static analysis and types is (for now) out of scope, and the patch limits itself to making the `Money` type usable in other contexts that are equally annotated as pure/immutable.

Adding more type safety is encouraged, but it would be a massive effort unless the library is first brought up to speed with PHP 7.3+ semantics.

Fixes #568