### PR TITLE
Cast integer amount to string

### DIFF
--- a/src/Formatter/IntlMoneyFormatter.php
+++ b/src/Formatter/IntlMoneyFormatter.php
@@ -38,7 +38,7 @@ final class IntlMoneyFormatter implements MoneyFormatter
      */
     public function format(Money $money)
     {
-        $valueBase = $money->getAmount();
+        $valueBase = (string) $money->getAmount();
         $negative = false;
 
         if ($valueBase[0] === '-') {


### PR DESCRIPTION
`$valueBase` is used as a string. To be strict we have to cast the amount to string first. 