### PR TITLE
GMP error when comparing fractions

### DIFF
--- a/src/Calculator/GmpCalculator.php
+++ b/src/Calculator/GmpCalculator.php
@@ -46,7 +46,10 @@ final class GmpCalculator implements Calculator
                 return $integersCompared;
             }
 
-            return gmp_cmp($aNum->getFractionalPart(), $bNum->getFractionalPart());
+            $aNumFractional = $aNum->getFractionalPart() === '' ? '0' : $aNum->getFractionalPart();
+            $bNumFractional = $bNum->getFractionalPart() === '' ? '0' : $bNum->getFractionalPart();
+
+            return gmp_cmp($aNumFractional, $bNumFractional);
         }
 
         return gmp_cmp($a, $b);

--- a/tests/Calculator/GmpCalculatorTest.php
+++ b/tests/Calculator/GmpCalculatorTest.php
@@ -29,4 +29,12 @@ class GmpCalculatorTest extends CalculatorTestCase
     {
         $this->assertSame('0', $this->getCalculator()->floor('0'));
     }
+    
+    /**
+     * @test
+     */
+    public function it_compares_zero_with_fraction()
+    {
+        $this->assertSame(1, $this->getCalculator()->compare('0.5', '0'));
+    }
 }

--- a/tests/Calculator/GmpCalculatorTest.php
+++ b/tests/Calculator/GmpCalculatorTest.php
@@ -29,7 +29,7 @@ class GmpCalculatorTest extends CalculatorTestCase
     {
         $this->assertSame('0', $this->getCalculator()->floor('0'));
     }
-    
+
     /**
      * @test
      */


### PR DESCRIPTION
Fixes #597 

When `GmpCalculator::compare` is passed arguments that result in the fractional parts being compared, i.e. integer parts the same, then if 1 has a fractional part and 1 doesn't, an empty string ends up being passed to `gmp_cmp` resulting in the error in the issue.

This PR makes sure valid values are passed to `gmp_cmp`.



