### PR TITLE
simplified static constructor

### DIFF
--- a/src/MoneyFactory.php
+++ b/src/MoneyFactory.php
@@ -205,4 +205,19 @@ trait MoneyFactory
     {
         return new Money($arguments[0], new Currency($method));
     }
+
+    /**
+     * @param int|string $amount Amount, expressed in the smallest units of $currency (eg cents)
+     * @param Currency|string $currency
+     *
+     * @return Money
+     * @throws \InvalidArgumentException If amount is not integer
+     * @throws \TypeError If currency is not a string or Currency object
+     */
+    public static function make($amount, $currency)
+    {
+        $currency = is_string($currency) ? new Currency($currency) : $currency;
+
+        return new Money($amount, $currency);
+    }
 }

--- a/tests/MoneyFactoryTest.php
+++ b/tests/MoneyFactoryTest.php
@@ -39,4 +39,13 @@ final class MoneyFactoryTest extends TestCase
 
         return $examples;
     }
+
+    /** @test */
+    public function it_parses_currency_as_string()
+    {
+        $this->assertEquals(
+            new Money(12345, new Currency('EUR')),
+            Money::make(12345, 'EUR')
+        );
+    }
 }


### PR DESCRIPTION
Introducing simplified static constructor without any change in the existing functionalities:

```php
new Money(12345, new Currency('EUR')) == Money::make(12345, 'EUR');
```

This example is trivial and doesn't really show the value gain.
However, in real world often both `amount` and `currency` are dynamic. Current constructors are not perfect:

```php
// ugly
Money::{$item->getCurrencyCode()}($item->getAmount())
// redundant Currency
new Money($item->getAmount(), new Currency($item->getCurrencyCode()))

// much more natural
Money::make($item->getAmount(), $item->getCurrencyCode())
```


Since in most cases currency is _just_ a 3-letter iso code and the object representation is really only a low-level implementation detail, this change should preferably go to the original constructor + something between the lines of:
```php
$currency = is_string($currency) ? new Currency($currency) : $currency;

if (!$currency instance Currency) {
    throw new \TypeError(
        'Argument 2 passed to Money/Money::__construct() must be an instance of Money/Currency or a string'
    ); // or trigger error if we still want to support eol php versions
}

$this->currency = $currency;
```

Such a change wouldn't be in principle BC breaking, but it could be problematic in some twisted cases using reflection. That is why this safe approach introducing a new static constructor.



PS: seems like cs & static tools are not configured to work on the relevant diff, but the whole codebase. Correct me if I'm wrong and there's anything I should do to make this PR green.