### PR TITLE
Rremove unnecessary ratio validation logic.

### DIFF
--- a/spec/MoneySpec.php
+++ b/spec/MoneySpec.php
@@ -335,16 +335,6 @@ final class MoneySpec extends ObjectBehavior
         $this->shouldThrow(\InvalidArgumentException::class)->duringAllocate([]);
     }
 
-    function it_throws_an_exception_when_allocation_ratio_is_negative()
-    {
-        $this->shouldThrow(\InvalidArgumentException::class)->duringAllocate([-1]);
-    }
-
-    function it_throws_an_exception_when_allocation_total_is_zero()
-    {
-        $this->shouldThrow(\InvalidArgumentException::class)->duringAllocate([0, 0]);
-    }
-
     function it_throws_an_exception_when_allocate_to_target_is_less_than_or_equals_zero()
     {
         $this->shouldThrow(\InvalidArgumentException::class)->duringAllocateTo(-1);

--- a/src/Money.php
+++ b/src/Money.php
@@ -352,14 +352,7 @@ final class Money implements \JsonSerializable
         $results = [];
         $total = array_sum($ratios);
 
-        if ($total <= 0) {
-            throw new \InvalidArgumentException('Cannot allocate to none, sum of ratios must be greater than zero');
-        }
-
         foreach ($ratios as $key => $ratio) {
-            if ($ratio < 0) {
-                throw new \InvalidArgumentException('Cannot allocate to none, ratio must be zero or positive');
-            }
             $share = $this->getCalculator()->share($this->amount, $ratio, $total);
             $results[$key] = $this->newInstance($share);
             $remainder = $this->getCalculator()->subtract($remainder, $share);


### PR DESCRIPTION
- Removed ratio validation logic that checks that the sum of ratios is non-negative.
- Removed ratio validation logic that prevented negative ratios.

Both of these methods currently block valid use cases for the allocate method.
In general, it should always be possible to allocate ratios as long as there is at least one non-negative ratio.
Guarding against this invariant should not be the responsibility of the money object.