### PR TITLE
Fix Money\Currency Json serialization

### DIFF
--- a/src/Currency.php
+++ b/src/Currency.php
@@ -82,7 +82,7 @@ final class Currency implements \JsonSerializable
     public function jsonSerialize()
     {
         return [
-            "code" => $this->code,
+            'code' => $this->code,
         ];
     }
 }

--- a/src/Currency.php
+++ b/src/Currency.php
@@ -77,10 +77,12 @@ final class Currency implements \JsonSerializable
     /**
      * {@inheritdoc}
      *
-     * @return string
+     * @return array
      */
     public function jsonSerialize()
     {
-        return $this->code;
+        return [
+            "code" => $this->code,
+        ];
     }
 }


### PR DESCRIPTION
`Currency` JSON serialization should return an indexed array, as it should be treated as an object in JSON.
Therefore, when serializing a Money object, the result should be like

```json
"moneyInstance": {
    "amount": "1000",
    "currency": { 
        "code": "EUR"
    }
}
```

Instead of 

```json
"moneyInstance": {
    "amount": "1000",
    "currency":  "EUR"
}
```