### PR TITLE
Variadic Money::isSameCurrency()

### DIFF
--- a/doc/features/comparison.rst
+++ b/doc/features/comparison.rst
@@ -8,7 +8,7 @@ A number of built in methods are available for comparing Money objects.
 Same Currency
 -------------
 
-``isSameCurrency()`` compares whether two Money objects have the same currency.
+``isSameCurrency()`` compares whether two or more Money objects have the same currency.
 
 .. code-block:: php
 
@@ -18,6 +18,26 @@ Same Currency
 
     $result = $value1->isSameCurrency($value2);    // true
     $result = $value1->isSameCurrency($value3);    // false
+
+``isSameCurrency()`` also accepts variadic arguments so that you can test whether all
+instances in a collection have the same currency as the target or not.
+
+.. code-block:: php
+
+    $target = Money::USD(800);
+
+    $containsEuros = [
+        Money::USD(500),
+        Money::EUR(800)
+    ];
+
+    $allDollars = [
+        Money::USD(500),
+        Money::USD(600),
+    ];
+
+    $result = $target->isSameCurrency(...$containsEuros); // false
+    $result = $target->isSameCurrency(...$allDollars);    // true
 
 .. _equality:
 

--- a/spec/MoneySpec.php
+++ b/spec/MoneySpec.php
@@ -83,6 +83,19 @@ final class MoneySpec extends ObjectBehavior
         $this->isSameCurrency(new Money(self::AMOUNT, new Currency(self::OTHER_CURRENCY)))->shouldReturn(false);
     }
 
+    function it_tests_currency_equality_with_multiple_arguments()
+    {
+        $this->isSameCurrency(
+            new Money(self::AMOUNT, new Currency(self::CURRENCY)),
+            new Money(self::AMOUNT, new Currency(self::CURRENCY))
+        )->shouldReturn(true);
+
+        $this->isSameCurrency(
+            new Money(self::AMOUNT, new Currency(self::CURRENCY)),
+            new Money(self::AMOUNT, new Currency(self::OTHER_CURRENCY))
+        )->shouldReturn(false);
+    }
+
     function it_equals_to_another_money()
     {
         $this->equals(new Money(self::AMOUNT, new Currency(self::CURRENCY)))->shouldReturn(true);

--- a/src/Money.php
+++ b/src/Money.php
@@ -94,13 +94,19 @@ final class Money implements \JsonSerializable
     }
 
     /**
-     * Checks whether a Money has the same Currency as this.
+     * Checks whether one or more Money instances have the same Currency as this.
      *
      * @return bool
      */
-    public function isSameCurrency(Money $other)
+    public function isSameCurrency(Money ...$other)
     {
-        return $this->currency->equals($other->currency);
+        foreach ($other as $money) {
+            if (! $this->currency->equals($money->currency)) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**

--- a/src/Money.php
+++ b/src/Money.php
@@ -101,7 +101,7 @@ final class Money implements \JsonSerializable
     public function isSameCurrency(Money ...$other)
     {
         foreach ($other as $money) {
-            if (! $this->currency->equals($money->currency)) {
+            if (!$this->currency->equals($money->currency)) {
                 return false;
             }
         }


### PR DESCRIPTION
I frequently need to check that multiple money instances are all the same currency - making `isSameCurrency()` variadic seemed like an innocuous and safe addition to me! 🤞