### PR TITLE
Fix #637: Ensure Currency::$code is uppercase

### DIFF
--- a/src/Currency.php
+++ b/src/Currency.php
@@ -33,7 +33,7 @@ final class Currency implements \JsonSerializable
             throw new \InvalidArgumentException('Currency code should not be empty string');
         }
 
-        $this->code = $code;
+        $this->code = strtoupper($code);
     }
 
     /**


### PR DESCRIPTION
Fix #637: Ensure `$code` is uppercase.

I proposed a PR using `strtoupper()` but, if you prefer, also `strtolower()` can be used.