### PR TITLE
Remove mention of older PHP versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,11 @@ The documentation is available at http://moneyphp.org
 
 ## Requirements
 
-PHP 5.6+. Other than that, this library has no external requirements. MoneyPHP will not provide any support to
-PHP versions that are [not supported by the language itself](http://php.net/supported-versions.php). There might be
+This library requires the BCMath PHP extension. There might be
 additional dependencies for specific feature, e.g. the Swap exchange implementation, check the documentation for more information.
+
+MoneyPHP will not provide any support to PHP versions that are
+[not supported by the language itself](http://php.net/supported-versions.php).
 
 
 ## Install

--- a/tests/MoneyTest.php
+++ b/tests/MoneyTest.php
@@ -376,7 +376,6 @@ final class MoneyTest extends TestCase
 
     /**
      * @test
-     * @requires PHP 7.0
      */
     public function itThrowsWhenCalculatingMinWithZeroArguments(): void
     {
@@ -386,7 +385,6 @@ final class MoneyTest extends TestCase
 
     /**
      * @test
-     * @requires PHP 7.0
      */
     public function itThrowsWhenCalculatingMaxWithZeroArguments(): void
     {
@@ -396,7 +394,6 @@ final class MoneyTest extends TestCase
 
     /**
      * @test
-     * @requires PHP 7.0
      */
     public function itThrowsWhenCalculatingSumWithZeroArguments(): void
     {
@@ -406,7 +403,6 @@ final class MoneyTest extends TestCase
 
     /**
      * @test
-     * @requires PHP 7.0
      */
     public function itThrowsWhenCalculatingAvgWithZeroArguments(): void
     {


### PR DESCRIPTION
`composer.json` is the source of truth for PHP requirements, and should
not be duplicated to reduce maintenance burden.