### PR TITLE
Update wording about minimum PHP version

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The documentation is available at http://moneyphp.org
 This library requires the BCMath PHP extension. There might be additional dependencies for specific feature, e.g. the
 Swap exchange implementation, check the documentation for more information.
 
-Version 4 is compatible with PHP 8.0. For older version of PHP, use version 3 of this library.
+Version 4 requires PHP 8.0. For older version of PHP, use version 3 of this library.
 
 
 ## Install


### PR DESCRIPTION
This should make it clearer that PHP 8 is the minimum.
Original wording looked more like it was now supported