### PR TITLE
Remove ext-json from required in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,7 @@
     ],
     "require": {
         "php": "^8.0",
-        "ext-bcmath": "*",
-        "ext-json": "*"
+        "ext-bcmath": "*"
     },
     "require-dev": {
         "ext-gmp": "*",


### PR DESCRIPTION
Extension JSON is [part](https://wiki.php.net/rfc/always_enable_json) of PHP core since version 8, there is no need to specify it in the composer.json file any longer. 