### PR TITLE
jsonSerialize() method made compatible with PHP 8.1

### DIFF
--- a/src/Currency.php
+++ b/src/Currency.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Money;
 
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 use function strtoupper;
 
@@ -59,6 +60,7 @@ final class Currency implements JsonSerializable
      *
      * @return string
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->code;

--- a/src/CurrencyPair.php
+++ b/src/CurrencyPair.php
@@ -6,6 +6,7 @@ namespace Money;
 
 use InvalidArgumentException;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 use function assert;
 use function is_numeric;
@@ -109,6 +110,7 @@ final class CurrencyPair implements JsonSerializable
      *
      * @return array
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [

--- a/src/Money.php
+++ b/src/Money.php
@@ -7,6 +7,7 @@ namespace Money;
 use InvalidArgumentException;
 use JsonSerializable;
 use Money\Calculator\BcMathCalculator;
+use ReturnTypeWillChange;
 
 use function array_fill;
 use function array_keys;
@@ -453,6 +454,7 @@ final class Money implements JsonSerializable
      *
      * @return array
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [


### PR DESCRIPTION
This library fails to work in PHP 8.1 environment because signatures of internal methods has changed
(see https://wiki.php.net/rfc/internal_method_return_types).

This PR adds #[ReturnTypeWillChange] attribute to jsonSerialize() methods to suppress deprecation warning on PHP 8.1.