### PR TITLE
Add `jsonSerialize` Return Types

### DIFF
--- a/src/Currency.php
+++ b/src/Currency.php
@@ -56,10 +56,8 @@ final class Currency implements JsonSerializable
 
     /**
      * {@inheritdoc}
-     *
-     * @return string
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): string
     {
         return $this->code;
     }

--- a/src/CurrencyPair.php
+++ b/src/CurrencyPair.php
@@ -107,9 +107,9 @@ final class CurrencyPair implements JsonSerializable
     /**
      * {@inheritdoc}
      *
-     * @return array
+     * @psalm-return array{baseCurrency: Currency, counterCurrency: Currency, ratio: numeric-string}
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return [
             'baseCurrency' => $this->baseCurrency,

--- a/src/Money.php
+++ b/src/Money.php
@@ -451,9 +451,9 @@ final class Money implements JsonSerializable
     /**
      * {@inheritdoc}
      *
-     * @return array
+     * @psalm-return array{amount: string, currency: string}
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return [
             'amount' => $this->amount,


### PR DESCRIPTION
Add `jsonSerialize` return types
- fixes PHP 8.1 deprecations
- shows array shapes where applicable

Addresses: https://github.com/moneyphp/money/issues/656
Related to PR: https://github.com/moneyphp/money/pull/670

While we can't say that Money fully supports 8.1 until the workflows are updated to run on it, the benefit of this is we don't have to wait for PHPSpec fixes from https://github.com/phpspec/phpspec/pull/1397. Once that is fixed we can have CI running on 8.1 as well. 

Also note that these changes are completely safe even without running workflows on 8.1.