### PR TITLE
Reduce PHP support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,13 +1,12 @@
 {
     "name": "moneyphp/money",
     "description": "PHP implementation of Fowler's Money pattern",
+    "license": "MIT",
     "keywords": [
         "money",
         "vo",
         "value object"
     ],
-    "homepage": "http://moneyphp.org",
-    "license": "MIT",
     "authors": [
         {
             "name": "Mathias Verraes",
@@ -23,6 +22,7 @@
             "email": "f.bosch@genkgo.nl"
         }
     ],
+    "homepage": "http://moneyphp.org",
     "require": {
         "php": "~8.0.0 || ~8.1.0",
         "ext-bcmath": "*",
@@ -55,6 +55,20 @@
         "florianv/swap": "Exchange rates library for PHP",
         "psr/cache-implementation": "Used for Currency caching"
     },
+    "minimum-stability": "dev",
+    "prefer-stable": true,
+    "autoload": {
+        "psr-4": {
+            "Money\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Benchmark\\Money\\": "benchmark/",
+            "Tests\\Money\\": "tests/",
+            "spec\\Money\\": "spec/"
+        }
+    },
     "config": {
         "sort-packages": true,
         "allow-plugins": {
@@ -68,20 +82,6 @@
             "dev-master": "3.x-dev"
         }
     },
-    "autoload": {
-        "psr-4": {
-            "Money\\": "src/"
-        }
-    },
-    "autoload-dev": {
-        "psr-4": {
-            "Benchmark\\Money\\": "benchmark/",
-            "Tests\\Money\\": "tests/",
-            "spec\\Money\\": "spec/"
-        }
-    },
-    "minimum-stability": "dev",
-    "prefer-stable": true,
     "scripts": {
         "benchmark": [
             "vendor/bin/phpbench run --retry-threshold=3 --iterations=15 --revs=1000  --warmup=2"

--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,12 @@
         "psr/cache-implementation": "Used for Currency caching"
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "infection/extension-installer": true,
+            "ergebnis/composer-normalize": true
+        }
     },
     "extra": {
         "branch-alias": {

--- a/composer.json
+++ b/composer.json
@@ -70,12 +70,12 @@
         }
     },
     "config": {
-        "sort-packages": true,
         "allow-plugins": {
             "dealerdirect/phpcodesniffer-composer-installer": true,
             "infection/extension-installer": true,
             "ergebnis/composer-normalize": true
-        }
+        },
+        "sort-packages": true
     },
     "extra": {
         "branch-alias": {

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "~8.0.0 || ~8.1.0",
         "ext-bcmath": "*",
         "ext-filter": "*",
         "ext-json": "*"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6a3c8440e30abb069ecf0a5ea9aa359c",
+    "content-hash": "688a15ab1cfc58520ca14b33cf4681fd",
     "packages": [],
     "packages-dev": [
         {
@@ -6938,7 +6938,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.0",
+        "php": "~8.0.0 || ~8.1.0",
         "ext-bcmath": "*",
         "ext-filter": "*",
         "ext-json": "*"
@@ -6947,5 +6947,5 @@
         "ext-gmp": "*",
         "ext-intl": "*"
     },
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.2.0"
 }


### PR DESCRIPTION
Following community discussions, I think we should opt-out to automatic support for every PHP 8 version. For now we fully support PHP 8.0, and have preliminary support for PHP 8.1. Since PHP does not follow semantic versioning (minor versions can have breaking changes), we should not communicate the support.