### PR TITLE
Fix: ISO parsing invalid assertions for CurrencyPair

### DIFF
--- a/spec/CurrencyPairSpec.php
+++ b/spec/CurrencyPairSpec.php
@@ -27,6 +27,14 @@ final class CurrencyPairSpec extends ObjectBehavior
         $this->shouldImplement(JsonSerializable::class);
     }
 
+    public function it_parses_an_iso_string(): void
+    {
+        $this->equals(
+            new CurrencyPair(new Currency('EUR'), new Currency('USD'), '1.250000'),
+            CurrencyPair::createFromIso('EUR/USD 1.250000')
+        );
+    }
+
     public function it_has_currencies_and_ratio(): void
     {
         $this->beConstructedWith($base = new Currency('EUR'), $counter = new Currency('USD'), $ratio = '1.0');

--- a/src/CurrencyPair.php
+++ b/src/CurrencyPair.php
@@ -62,7 +62,7 @@ final class CurrencyPair implements JsonSerializable
         }
 
         assert($matches[1] !== '');
-        assert(is_numeric($matches[2]));
+        assert($matches[2] !== '');
         assert(is_numeric($matches[3]));
 
         return new self(new Currency($matches[1]), new Currency($matches[2]), $matches[3]);

--- a/src/CurrencyPair.php
+++ b/src/CurrencyPair.php
@@ -62,7 +62,8 @@ final class CurrencyPair implements JsonSerializable
         }
 
         assert($matches[1] !== '');
-        assert($matches[2] !== '');
+        assert(is_numeric($matches[2]));
+        // TODO: assert($matches[2] !== '');
         assert(is_numeric($matches[3]));
 
         return new self(new Currency($matches[1]), new Currency($matches[2]), $matches[3]);


### PR DESCRIPTION
With iso as `EUR/USD 1.2500`, we will get `$matches = ['EUR/USD 1.2500', 'EUR', 'USD', '1.2500']` after `pref_match` but the assertion expects `$matches[2]` to be numeric which seems to be incorrect. Just updated the assertion to not expect an empty string.

```diff
assert($matches[1] !== '');
- assert(is_numeric($matches[2]));
+ assert($matches[2] !== '');

```

fixes #695

> **Warning** : Not ready for merge. 
> The changes have been reverted to showcase the issue with existing implementation.