### PR TITLE
The comment is slightly different from the class 'MoneyFactory'

### DIFF
--- a/src/Money.php
+++ b/src/Money.php
@@ -71,7 +71,7 @@ final class Money implements JsonSerializable
      * @param int|string $amount Amount, expressed in the smallest units of $currency (eg cents)
      * @psalm-param int|numeric-string $amount
      *
-     * @throws InvalidArgumentException If amount is not integer.
+     * @throws InvalidArgumentException If amount is not integer(ish).
      */
     public function __construct(int|string $amount, Currency $currency)
     {


### PR DESCRIPTION
Hi,
This tiny PR harmonizes the `@throws InvalidArgumentException` comment in the `Money` class, because the same `@throws InvalidArgumentException` in `MoneyFactory` class is slightly different.