### PR TITLE
Accept leading zeros

### DIFF
--- a/doc/getting-started.rst
+++ b/doc/getting-started.rst
@@ -19,7 +19,7 @@ See :doc:`features/parsing` for additional ways to instantiate a Money object fr
 
 Accepted integer values
 -----------------------
-The Money object only supports integer(ish) values on instantiation. The following is (not) supported. When a
+The Money object only supports integer(ish) values on instantiation. The following is supported. When a
 non-supported value is passed a `\InvalidArgumentException` will be thrown.
 
 .. code-block:: php
@@ -36,10 +36,10 @@ non-supported value is passed a `\InvalidArgumentException` will be thrown.
     // string is accepted if fractional part is zero
     $fiver = new Money('500.00', new Currency('USD'));
 
-    // leading zero's are not accepted
+    // leading zero's are accepted
     $fiver = new Money('00500', new Currency('USD'));
 
-    // multiple zero's are not accepted
+    // multiple zero's are accepted
     $fiver = new Money('000', new Currency('USD'));
 
 

--- a/src/Number.php
+++ b/src/Number.php
@@ -11,6 +11,7 @@ use function explode;
 use function is_int;
 use function ltrim;
 use function min;
+use function preg_replace;
 use function rtrim;
 use function sprintf;
 use function str_pad;
@@ -188,6 +189,7 @@ final class Number
      */
     private static function parseIntegerPart(string $number): string
     {
+        $number = preg_replace('/^(-?)0+(\d)/', '$1$2', $number);
         if ($number === '' || $number === '0') {
             return '0';
         }
@@ -202,8 +204,6 @@ final class Number
             return $number;
         }
 
-        $nonZero = false;
-
         for ($position = 0, $characters = strlen($number); $position < $characters; ++$position) {
             $digit = $number[$position];
 
@@ -211,12 +211,6 @@ final class Number
             if (! isset(self::NUMBERS[$digit]) && ! ($position === 0 && $digit === '-')) {
                 throw new InvalidArgumentException(sprintf('Invalid integer part %1$s. Invalid digit %2$s found', $number, $digit));
             }
-
-            if ($nonZero === false && $digit === '0') {
-                throw new InvalidArgumentException('Leading zeros are not allowed');
-            }
-
-            $nonZero = true;
         }
 
         return $number;

--- a/tests/MoneyTest.php
+++ b/tests/MoneyTest.php
@@ -373,6 +373,18 @@ final class MoneyTest extends TestCase
     }
 
     /**
+     * @psalm-param numeric-string $amount
+     * @psalm-param numeric-string $result
+     *
+     * @dataProvider leadingZerosExamples
+     * @test
+     */
+    public function itSupportLeadingZeros(string $amount, string $result): void
+    {
+        self::assertEquals($result, (new Money($amount, new Currency(self::CURRENCY)))->getAmount());
+    }
+
+    /**
      * @psalm-return non-empty-list<array{
      *     int|numeric-string,
      *     Currency,
@@ -550,6 +562,24 @@ final class MoneyTest extends TestCase
             [5, 1, 10],
             [10, 1, 10],
             [10, 8, 0],
+        ];
+    }
+
+    /**
+     * @psalm-return non-empty-list<array{
+     *     numeric-string,
+     *     numeric-string
+     * }>
+     */
+    public function leadingZerosExamples(): array
+    {
+        return [
+            ['000', '0'],
+            ['000.00', '0'],
+            ['005', '5'],
+            ['005.00', '5'],
+            ['00500', '500'],
+            ['-00500', '-500'],
         ];
     }
 }

--- a/tests/NumberTest.php
+++ b/tests/NumberTest.php
@@ -125,6 +125,9 @@ final class NumberTest extends TestCase
             ['-10.5', true, true, true, true, '-10', '5'],
             ['-.5', true, true, true, true, '-0', '5'],
             ['.5', true, true, true, false, '0', '5'],
+            ['000', false, false, true, false, '0', ''],
+            ['005', false, false, false, false, '5', ''],
+            ['-005', false, false, false, true, '-5', ''],
             [(string) PHP_INT_MAX, false, false, false, false, (string) PHP_INT_MAX, ''],
             [(string) -PHP_INT_MAX, false, false, false, true, (string) -PHP_INT_MAX, ''],
             [
@@ -162,8 +165,6 @@ final class NumberTest extends TestCase
     {
         return [
             [''],
-            ['000'],
-            ['005'],
             ['123456789012345678-123456'],
             ['---123'],
             ['123456789012345678+13456'],


### PR DESCRIPTION
This is a direct follow-up to 2f1dbf1afde48dbe98402e5e8aa450434def234f, from #702,
that started to allow leading zeros in some places, but did not actually allow them everywhere.