### PR TITLE
Add underlying provider name to the currency pair

### DIFF
--- a/spec/CurrencyPairSpec.php
+++ b/spec/CurrencyPairSpec.php
@@ -14,7 +14,7 @@ final class CurrencyPairSpec extends ObjectBehavior
 {
     public function let(): void
     {
-        $this->beConstructedWith(new Currency('EUR'), new Currency('USD'), '1.250000');
+        $this->beConstructedWith(new Currency('EUR'), new Currency('USD'), '1.250000', 'fixed');
     }
 
     public function it_is_initializable(): void
@@ -47,5 +47,10 @@ final class CurrencyPairSpec extends ObjectBehavior
     public function it_throws_an_exception_when_iso_string_cannot_be_parsed(): void
     {
         $this->shouldThrow(InvalidArgumentException::class)->duringCreateFromIso('1.250000');
+    }
+
+    public function it_returns_the_provider_name_when_asked_for(): void
+    {
+        $this->providerName()->shouldReturn('fixed');
     }
 }

--- a/spec/Exchange/FixedExchangeSpec.php
+++ b/spec/Exchange/FixedExchangeSpec.php
@@ -17,7 +17,7 @@ final class FixedExchangeSpec extends ObjectBehavior
     {
         $this->beConstructedWith([
             'EUR' => ['USD' => '1.25'],
-        ]);
+        ], 'provider-name');
     }
 
     public function it_is_initializable(): void

--- a/src/CurrencyPair.php
+++ b/src/CurrencyPair.php
@@ -32,14 +32,18 @@ final class CurrencyPair implements JsonSerializable
     /** @psalm-var numeric-string */
     private string $conversionRatio;
 
+    /** @psalm-var non-empty-string **/
+    private string $providerName;
+
     /**
      * @psalm-param numeric-string $conversionRatio
      */
-    public function __construct(Currency $baseCurrency, Currency $counterCurrency, string $conversionRatio)
+    public function __construct(Currency $baseCurrency, Currency $counterCurrency, string $conversionRatio, string $providerName = '')
     {
         $this->counterCurrency = $counterCurrency;
         $this->baseCurrency    = $baseCurrency;
         $this->conversionRatio = $conversionRatio;
+        $this->providerName    = $providerName;
     }
 
     /**
@@ -94,6 +98,11 @@ final class CurrencyPair implements JsonSerializable
         return $this->conversionRatio;
     }
 
+    public function providerName(): string
+    {
+        return $this->providerName;
+    }
+
     /**
      * Checks if an other CurrencyPair has the same parameters as this.
      */
@@ -115,6 +124,7 @@ final class CurrencyPair implements JsonSerializable
             'baseCurrency' => $this->baseCurrency,
             'counterCurrency' => $this->counterCurrency,
             'ratio' => $this->conversionRatio,
+            'providerName' => $this->providerName,
         ];
     }
 }

--- a/src/Exchange/ExchangerExchange.php
+++ b/src/Exchange/ExchangerExchange.php
@@ -44,6 +44,6 @@ final class ExchangerExchange implements Exchange
 
         assert(is_numeric($rateValue));
 
-        return new CurrencyPair($baseCurrency, $counterCurrency, $rateValue);
+        return new CurrencyPair($baseCurrency, $counterCurrency, $rateValue, $rate->getProviderName());
     }
 }

--- a/src/Exchange/FixedExchange.php
+++ b/src/Exchange/FixedExchange.php
@@ -17,10 +17,14 @@ final class FixedExchange implements Exchange
     /** @psalm-var array<non-empty-string, array<non-empty-string, numeric-string>> */
     private array $list;
 
+    /** @psalm-var non-empty-string  */
+    private string $providerName;
+
     /** @psalm-param array<non-empty-string, array<non-empty-string, numeric-string>> $list */
-    public function __construct(array $list)
+    public function __construct(array $list, string $providerName = 'fixed')
     {
         $this->list = $list;
+        $this->providerName = $providerName;
     }
 
     public function quote(Currency $baseCurrency, Currency $counterCurrency): CurrencyPair
@@ -29,7 +33,8 @@ final class FixedExchange implements Exchange
             return new CurrencyPair(
                 $baseCurrency,
                 $counterCurrency,
-                $this->list[$baseCurrency->getCode()][$counterCurrency->getCode()]
+                $this->list[$baseCurrency->getCode()][$counterCurrency->getCode()],
+                $this->providerName
             );
         }
 

--- a/src/Exchange/ReversedCurrenciesExchange.php
+++ b/src/Exchange/ReversedCurrenciesExchange.php
@@ -37,7 +37,8 @@ final class ReversedCurrenciesExchange implements Exchange
                 return new CurrencyPair(
                     $baseCurrency,
                     $counterCurrency,
-                    $calculator::divide('1', $currencyPair->getConversionRatio())
+                    $calculator::divide('1', $currencyPair->getConversionRatio()),
+                    $currencyPair->providerName()
                 );
             } catch (UnresolvableCurrencyPairException) {
                 throw $exception;

--- a/src/Exchange/SwapExchange.php
+++ b/src/Exchange/SwapExchange.php
@@ -31,6 +31,6 @@ final class SwapExchange implements Exchange
             throw UnresolvableCurrencyPairException::createFromCurrencies($baseCurrency, $counterCurrency);
         }
 
-        return new CurrencyPair($baseCurrency, $counterCurrency, (string) $rate->getValue());
+        return new CurrencyPair($baseCurrency, $counterCurrency, (string) $rate->getValue(), $rate->getProviderName());
     }
 }

--- a/tests/CurrencyPairTest.php
+++ b/tests/CurrencyPairTest.php
@@ -18,7 +18,7 @@ final class CurrencyPairTest extends TestCase
      */
     public function itConvertsToJson(): void
     {
-        $expectedJson = '{"baseCurrency":"EUR","counterCurrency":"USD","ratio":"1.25"}';
+        $expectedJson = '{"baseCurrency":"EUR","counterCurrency":"USD","ratio":"1.25","providerName":""}';
         $actualJson   = json_encode(new CurrencyPair(new Currency('EUR'), new Currency('USD'), '1.25'));
 
         self::assertEquals($expectedJson, $actualJson);

--- a/tests/Exchange/ExchangerExchangeTest.php
+++ b/tests/Exchange/ExchangerExchangeTest.php
@@ -29,6 +29,9 @@ final class ExchangerExchangeTest extends TestCase
             ->with(self::equalTo(new ExchangeRateQuery(new ExchangerCurrencyPair('EUR', 'USD'))))
             ->willReturn($exchangeRate);
 
+        $exchangeRate->method('getProviderName')
+            ->willReturn('some-provider');
+
         $base         = new Currency('EUR');
         $counter      = new Currency('USD');
         $currencyPair = (new ExchangerExchange($exchangeRates))
@@ -37,6 +40,7 @@ final class ExchangerExchangeTest extends TestCase
         self::assertEquals($base, $currencyPair->getBaseCurrency());
         self::assertEquals($counter, $currencyPair->getCounterCurrency());
         self::assertEquals('1.12000000000000', $currencyPair->getConversionRatio());
+        self::assertEquals('some-provider', $currencyPair->providerName());
     }
 
     /** @test */

--- a/tests/Exchange/IndirectExchangeTest.php
+++ b/tests/Exchange/IndirectExchangeTest.php
@@ -27,6 +27,7 @@ final class IndirectExchangeTest extends TestCase
         self::assertEquals('USD', $pair->getBaseCurrency()->getCode());
         self::assertEquals('AOA', $pair->getCounterCurrency()->getCode());
         self::assertEquals(12, $pair->getConversionRatio());
+        self::assertEquals('fixed', $pair->providerName());
     }
 
     private function createExchange(): IndirectExchange

--- a/tests/Exchange/ReversedCurrenciesExchangeTest.php
+++ b/tests/Exchange/ReversedCurrenciesExchangeTest.php
@@ -23,10 +23,10 @@ final class ReversedCurrenciesExchangeTest extends TestCase
 
         $wrappedExchange->method('quote')
             ->with(self::equalTo($base), self::equalTo($counter))
-            ->willReturn(new CurrencyPair($base, $counter, '1.25'));
+            ->willReturn(new CurrencyPair($base, $counter, '1.25', 'reversed'));
 
         self::assertEquals(
-            new CurrencyPair($base, $counter, '1.25'),
+            new CurrencyPair($base, $counter, '1.25', 'reversed'),
             (new ReversedCurrenciesExchange($wrappedExchange))
                 ->quote($base, $counter)
         );

--- a/tests/Exchange/SwapExchangeTest.php
+++ b/tests/Exchange/SwapExchangeTest.php
@@ -27,13 +27,16 @@ final class SwapExchangeTest extends TestCase
         $exchangeRate->method('getValue')
             ->willReturn(1.25);
 
+        $exchangeRate->method('getProviderName')
+            ->willReturn('some-provider');
+
         $swapExchange->expects(self::once())
             ->method('latest')
             ->with('EUR/USD')
             ->willReturn($exchangeRate);
 
         self::assertEquals(
-            new CurrencyPair($base, $counter, '1.25'),
+            new CurrencyPair($base, $counter, '1.25', 'some-provider'),
             (new SwapExchange($swapExchange))
                 ->quote($base, $counter)
         );


### PR DESCRIPTION
Hey MoneyPHP team.

I am doing some currency conversations using the swap implementation as the baseline, which internally uses the exchange framework behind the scenes using its chain functionality.

I have been asked to save the conversion rate and the provider that was used to fetch that conversion rate somewhere. Which brings up a question that i am trying to solve "How can i get the provider that was used to fetch the conversion rate?"

I believe i have managed to solve that issue for the different implementations that we have for our exchange functionality by also allowing the "CurrencyPair" to hold that information for us.

I hope this will make it in so i can get the context i need.

If changing method signatures is considered a breaking change i would be open for changing that around.