### PR TITLE
Support PHP 8.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: ['8.0', '8.1']
+        php: ['8.0', '8.1', '8.2']
 
     steps:
       - name: Set up PHP

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: ['8.0', '8.1', '8.2']
+        php:
+         - '8.0'
+         - '8.1'
+         - '8.2'
 
     steps:
       - name: Set up PHP

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     ],
     "homepage": "http://moneyphp.org",
     "require": {
-        "php": "~8.0.0 || ~8.1.0",
+        "php": "~8.0.0 || ~8.1.0 || ~8.2.0",
         "ext-bcmath": "*",
         "ext-filter": "*",
         "ext-json": "*"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6bc8ca17fb17cc7730b9553c64bdaa3b",
+    "content-hash": "dbd3a918e59702357efbe6ae033c240f",
     "packages": [],
     "packages-dev": [
         {
@@ -6245,7 +6245,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": "~8.0.0 || ~8.1.0",
+        "php": "~8.0.0 || ~8.1.0 || ~8.2.0",
         "ext-bcmath": "*",
         "ext-filter": "*",
         "ext-json": "*"


### PR DESCRIPTION
Seems PHP 8.2 is supported without having to make any changes.

phpspec is not supporting 8.2 yet, but [work is in progress](https://github.com/phpspec/phpspec/pull/1435). This is blocking us from adding php 8.2 support for now with the current set of requirements.