### PR TITLE
Update CLP for 2 minorUnit

### DIFF
--- a/resources/currency.php
+++ b/resources/currency.php
@@ -255,7 +255,7 @@
   array (
     'alphabeticCode' => 'CLP',
     'currency' => 'Chilean Peso',
-    'minorUnit' => 0,
+    'minorUnit' => 2,
     'numericCode' => 152,
   ),
   'CLF' => 


### PR DESCRIPTION
The ISO 4217 code for the present peso is CLP. It was officially subdivided into 100 centavos, until the subdivision was eliminated in 1984 due to its low value.
Info:
https://en.wikipedia.org/wiki/Chilean_peso
https://en.wikipedia.org/wiki/Centavo