### PR TITLE
Money::ratioOf throws exception if currencies don't match

### DIFF
--- a/src/Money.php
+++ b/src/Money.php
@@ -363,6 +363,11 @@ final class Money implements JsonSerializable
             throw new InvalidArgumentException('Cannot calculate a ratio of zero');
         }
 
+        // Note: non-strict equality is intentional here, since `Currency` is `final` and reliable.
+        if ($this->currency != $money->currency) {
+            throw new InvalidArgumentException('Currencies must be identical');
+        }
+
         return self::$calculator::divide($this->amount, $money->amount);
     }
 

--- a/tests/MoneyTest.php
+++ b/tests/MoneyTest.php
@@ -339,7 +339,6 @@ final class MoneyTest extends TestCase
 
         $this->expectException(InvalidArgumentException::class);
 
-        /** @psalm-suppress UnusedMethodCall this method throws */
         $money->ratioOf($rightMoney);
     }
 

--- a/tests/MoneyTest.php
+++ b/tests/MoneyTest.php
@@ -260,6 +260,20 @@ final class MoneyTest extends TestCase
     /**
      * @test
      */
+    public function itThrowsWhenCalculatingModulusOfDifferentCurrencies(): void
+    {
+        $money      = new Money(self::AMOUNT, new Currency(self::CURRENCY));
+        $rightMoney = new Money(self::OTHER_AMOUNT, new Currency(self::OTHER_CURRENCY));
+
+        $this->expectException(InvalidArgumentException::class);
+
+        /** @psalm-suppress UnusedMethodCall this method throws */
+        $money->mod($rightMoney);
+    }
+
+    /**
+     * @test
+     */
     public function itConvertsToJson(): void
     {
         self::assertEquals(
@@ -313,6 +327,20 @@ final class MoneyTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
 
         $six->ratioOf($zero);
+    }
+
+    /**
+     * @test
+     */
+    public function itThrowsWhenCalculatingRatioOfDifferentCurrencies(): void
+    {
+        $money      = new Money(self::AMOUNT, new Currency(self::CURRENCY));
+        $rightMoney = new Money(self::OTHER_AMOUNT, new Currency(self::OTHER_CURRENCY));
+
+        $this->expectException(InvalidArgumentException::class);
+
+        /** @psalm-suppress UnusedMethodCall this method throws */
+        $money->mod($rightMoney);
     }
 
     /**

--- a/tests/MoneyTest.php
+++ b/tests/MoneyTest.php
@@ -340,7 +340,7 @@ final class MoneyTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
 
         /** @psalm-suppress UnusedMethodCall this method throws */
-        $money->mod($rightMoney);
+        $money->ratioOf($rightMoney);
     }
 
     /**


### PR DESCRIPTION
I also added a test case for `Money::mod` which already performs currency check.

fixes #732