### PR TITLE
abstract CurrencyPair to an interface

### DIFF
--- a/doc/features/currency-conversion.rst
+++ b/doc/features/currency-conversion.rst
@@ -186,3 +186,14 @@ A currency pair can be used to convert an amount.
     $converter = new Converter(new ISOCurrencies(), $exchange);
     $eur100 = Money::EUR(100);
     $usd125 = $converter->convertAgainstCurrencyPair($eur100, $pair);
+
+Implementing your own CurrencyPair
+------------
+Sometimes you would like to have retrieve more data than our CurrencyPair provides
+perhaps you would like to store which date the currency conversion was made.
+
+In order to do so you can create your very own CurrencyPair valueObject.
+
+That object needs to implement \Money\Exchange\CurrencyPair.
+
+Then you can create your own exchange and have it return that CurrencyPair instead of the default \Money\CurrencyPair object.

--- a/src/Converter.php
+++ b/src/Converter.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Money;
 
 use InvalidArgumentException;
+use Money\Exchange\CurrencyPair;
 
 use function sprintf;
 

--- a/src/Exchange.php
+++ b/src/Exchange.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Money;
 
 use Money\Exception\UnresolvableCurrencyPairException;
+use Money\Exchange\CurrencyPair;
 
 /**
  * Provides a way to get exchange rate from a third-party source and return a currency pair.

--- a/src/Exchange/CurrencyPair.php
+++ b/src/Exchange/CurrencyPair.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Money\Exchange;
+
+use InvalidArgumentException;
+use Money\Currency;
+
+interface CurrencyPair
+{
+    /**
+     * Creates a new Currency Pair based on "EUR/USD 1.2500" form representation.
+     *
+     * @param string $iso String representation of the form "EUR/USD 1.2500"
+     *
+     * @throws InvalidArgumentException Format of $iso is invalid.
+     */
+    public static function createFromIso(string $iso): self;
+
+    /**
+     * Returns the conversion ratio.
+     *
+     * @psalm-return numeric-string
+     */
+    public function getConversionRatio(): string;
+
+    /**
+     * Returns the counter currency.
+     */
+    public function getCounterCurrency(): Currency;
+
+    /**
+     * Returns the base currency.
+     */
+    public function getBaseCurrency(): Currency;
+
+    /**
+     * Checks if an other CurrencyPair has the same parameters as this.
+     */
+    public function equals(CurrencyPair $other): bool;
+}

--- a/src/Exchange/ExchangerExchange.php
+++ b/src/Exchange/ExchangerExchange.php
@@ -29,7 +29,7 @@ final class ExchangerExchange implements Exchange
         $this->exchanger = $exchanger;
     }
 
-    public function quote(Currency $baseCurrency, Currency $counterCurrency): CurrencyPair
+    public function quote(Currency $baseCurrency, Currency $counterCurrency): \Money\Exchange\CurrencyPair
     {
         try {
             $query = new ExchangeRateQuery(

--- a/src/Exchange/FixedExchange.php
+++ b/src/Exchange/FixedExchange.php
@@ -6,6 +6,7 @@ namespace Money\Exchange;
 
 use Money\Currency;
 use Money\CurrencyPair;
+use Money\Exchange\CurrencyPair as CurrencyPairContract;
 use Money\Exception\UnresolvableCurrencyPairException;
 use Money\Exchange;
 
@@ -23,7 +24,7 @@ final class FixedExchange implements Exchange
         $this->list = $list;
     }
 
-    public function quote(Currency $baseCurrency, Currency $counterCurrency): CurrencyPair
+    public function quote(Currency $baseCurrency, Currency $counterCurrency): CurrencyPairContract
     {
         if (isset($this->list[$baseCurrency->getCode()][$counterCurrency->getCode()])) {
             return new CurrencyPair(

--- a/src/Exchange/IndirectExchange.php
+++ b/src/Exchange/IndirectExchange.php
@@ -9,6 +9,7 @@ use Money\Currency;
 use Money\CurrencyPair;
 use Money\Exception\UnresolvableCurrencyPairException;
 use Money\Exchange;
+use Money\Exchange\CurrencyPair as CurrencyPairContract;
 use Money\Money;
 use SplQueue;
 
@@ -30,7 +31,7 @@ final class IndirectExchange implements Exchange
         $this->currencies = $currencies;
     }
 
-    public function quote(Currency $baseCurrency, Currency $counterCurrency): CurrencyPair
+    public function quote(Currency $baseCurrency, Currency $counterCurrency): CurrencyPairContract
     {
         try {
             return $this->exchange->quote($baseCurrency, $counterCurrency);
@@ -42,7 +43,7 @@ final class IndirectExchange implements Exchange
                  *
                  * @psalm-return numeric-string
                  */
-                static function (string $carry, CurrencyPair $pair) {
+                static function (string $carry, CurrencyPairContract $pair) {
                     $calculator = Money::getCalculator();
 
                     return $calculator::multiply($carry, $pair->getConversionRatio());
@@ -55,7 +56,7 @@ final class IndirectExchange implements Exchange
     }
 
     /**
-     * @return CurrencyPair[]
+     * @return CurrencyPairContract[]
      *
      * @throws UnresolvableCurrencyPairException
      */
@@ -111,8 +112,8 @@ final class IndirectExchange implements Exchange
     /**
      * @psalm-param array<non-empty-string, IndirectExchangeQueuedItem> $currencies
      *
-     * @return CurrencyPair[]
-     * @psalm-return list<CurrencyPair>
+     * @return CurrencyPairContract[]
+     * @psalm-return list<CurrencyPairContract>
      */
     private function reconstructConversionChain(array $currencies, IndirectExchangeQueuedItem $goalNode): array
     {

--- a/src/Exchange/ReversedCurrenciesExchange.php
+++ b/src/Exchange/ReversedCurrenciesExchange.php
@@ -6,6 +6,7 @@ namespace Money\Exchange;
 
 use Money\Currency;
 use Money\CurrencyPair;
+use Money\Exchange\CurrencyPair as CurrencyPairContract;
 use Money\Exception\UnresolvableCurrencyPairException;
 use Money\Exchange;
 use Money\Money;
@@ -24,7 +25,7 @@ final class ReversedCurrenciesExchange implements Exchange
         $this->exchange = $exchange;
     }
 
-    public function quote(Currency $baseCurrency, Currency $counterCurrency): CurrencyPair
+    public function quote(Currency $baseCurrency, Currency $counterCurrency): CurrencyPairContract
     {
         try {
             return $this->exchange->quote($baseCurrency, $counterCurrency);

--- a/src/Exchange/SwapExchange.php
+++ b/src/Exchange/SwapExchange.php
@@ -23,7 +23,7 @@ final class SwapExchange implements Exchange
         $this->swap = $swap;
     }
 
-    public function quote(Currency $baseCurrency, Currency $counterCurrency): CurrencyPair
+    public function quote(Currency $baseCurrency, Currency $counterCurrency): \Money\Exchange\CurrencyPair
     {
         try {
             $rate = $this->swap->latest($baseCurrency->getCode() . '/' . $counterCurrency->getCode());

--- a/tests/CurrencyPairTest.php
+++ b/tests/CurrencyPairTest.php
@@ -24,6 +24,14 @@ final class CurrencyPairTest extends TestCase
         self::assertEquals($expectedJson, $actualJson);
     }
 
+    /**
+     * @test
+     */
+    public function it_implements_currencyPair(): void
+    {
+        self::assertInstanceOf(\Money\Exchange\CurrencyPair::class, new CurrencyPair(new Currency('EUR'), new Currency('USD'), '1.250000'));
+    }
+
     /** @test */
     public function it_parses_an_iso_string(): void
     {

--- a/tests/Exchange/ExchangerExchangeTest.php
+++ b/tests/Exchange/ExchangerExchangeTest.php
@@ -11,6 +11,7 @@ use Exchanger\Exception\Exception;
 use Exchanger\ExchangeRateQuery;
 use Money\Currency;
 use Money\Exception\UnresolvableCurrencyPairException;
+use Money\Exchange\CurrencyPair;
 use Money\Exchange\ExchangerExchange;
 use PHPUnit\Framework\TestCase;
 
@@ -37,6 +38,7 @@ final class ExchangerExchangeTest extends TestCase
         self::assertEquals($base, $currencyPair->getBaseCurrency());
         self::assertEquals($counter, $currencyPair->getCounterCurrency());
         self::assertEquals('1.12000000000000', $currencyPair->getConversionRatio());
+        self::assertInstanceOf(CurrencyPair::class, $currencyPair);
     }
 
     /** @test */


### PR DESCRIPTION
Currently we can create our own Exchange objects, but we are forced to use this library's CurrencyPair ValueObject.

This Pull Request tries to lift that restriction by extracting the methods inside the CurrencyPair into an interface that can be used as a return value while implementing our own Exchange values. 

The use-case is to allow calling converter#convertAndReturnWithCurrencyPair and have it return my custom implementation back to me if i implement my own Exchange implementation. 

Previously it was impossible to retrieve any other information from the CurrencyPair other than the currencies involved and the Rate for it. With this proposal a Developer would be able to provide their own implementation and that implementation could consist of e.g. the date or the underlaying provider used for the exchange. 

Superseds #710.

Maybe we should even provide a trait for very basic logic that currently goes into creating the CurrencyPair ValueObject?

What do you think of this?