### PR TITLE
Optimize result representation for BcMathCalculator

### DIFF
--- a/benchmark/Calculator/BcMathCalculatorBench.php
+++ b/benchmark/Calculator/BcMathCalculatorBench.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Benchmark\Money\Calculator;
+
+use Money\Calculator\BcMathCalculator;
+
+class BcMathCalculatorBench extends CalculatorBench
+{
+    protected function getCalculator(): string
+    {
+        return BcMathCalculator::class;
+    }
+}

--- a/benchmark/Calculator/CalculatorBench.php
+++ b/benchmark/Calculator/CalculatorBench.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Benchmark\Money\Calculator;
+
+use Money\Calculator;
+use Money\Money;
+
+abstract class CalculatorBench
+{
+    /**
+     * @psalm-return class-string<Calculator>
+     */
+    abstract protected function getCalculator(): string;
+
+    public function benchCompare(): void
+    {
+        $this->getCalculator()::compare('1', '1');
+        $this->getCalculator()::compare('1', '5');
+        $this->getCalculator()::compare('5', '5');
+        $this->getCalculator()::compare('5.5', '1.5');
+        $this->getCalculator()::compare('1.5', '5.5');
+    }
+
+    public function benchAdd(): void
+    {
+        $this->getCalculator()::add('1', '5');
+    }
+
+    public function benchSubtract(): void
+    {
+        $this->getCalculator()::subtract('1', '5');
+    }
+
+    public function benchMultiply(): void
+    {
+        $this->getCalculator()::multiply('5', '25');
+        $this->getCalculator()::multiply('5', '1.5');
+    }
+
+    public function benchDivide(): void
+    {
+        $this->getCalculator()::divide('5', '4');
+    }
+
+    public function benchCeil(): void
+    {
+        $this->getCalculator()::ceil('5.5');
+    }
+
+    public function benchFloor(): void
+    {
+        $this->getCalculator()::floor('5.5');
+    }
+
+    public function benchAbsolute(): void
+    {
+        $this->getCalculator()::absolute('5');
+        $this->getCalculator()::absolute('-5');
+    }
+
+    public function benchRound(): void
+    {
+        $this->getCalculator()::round('2.6', Money::ROUND_HALF_EVEN);
+    }
+
+    public function benchShare(): void
+    {
+        $this->getCalculator()::share('10', '2', '4');
+    }
+
+    public function benchMod(): void
+    {
+        $this->getCalculator()::mod('11', '5');
+    }
+}

--- a/benchmark/Calculator/GmpCalculatorBench.php
+++ b/benchmark/Calculator/GmpCalculatorBench.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Benchmark\Money\Calculator;
+
+use Money\Calculator\GmpCalculator;
+
+class GmpCalculatorBench extends CalculatorBench
+{
+    protected function getCalculator(): string
+    {
+        return GmpCalculator::class;
+    }
+}

--- a/benchmark/MoneyOperationBench.php
+++ b/benchmark/MoneyOperationBench.php
@@ -57,12 +57,12 @@ final class MoneyOperationBench
 
     public function benchMax(): void
     {
-        Money::min($this->a, $this->b, $this->a, $this->b);
+        Money::max($this->a, $this->b, $this->a, $this->b);
     }
 
     public function benchAvg(): void
     {
-        Money::min($this->a, $this->b, $this->a, $this->b);
+        Money::avg($this->a, $this->b, $this->a, $this->b);
     }
 
     public function benchRatioOf(): void

--- a/src/Calculator/BcMathCalculator.php
+++ b/src/Calculator/BcMathCalculator.php
@@ -17,6 +17,7 @@ use function bcmod;
 use function bcmul;
 use function bcsub;
 use function ltrim;
+use function str_contains;
 
 final class BcMathCalculator implements Calculator
 {
@@ -31,13 +32,17 @@ final class BcMathCalculator implements Calculator
     /** @psalm-pure */
     public static function add(string $amount, string $addend): string
     {
-        return bcadd($amount, $addend, self::SCALE);
+        $scale = str_contains($amount, '.') || str_contains($addend, '.') ? self::SCALE : 0;
+
+        return bcadd($amount, $addend, $scale);
     }
 
     /** @psalm-pure */
     public static function subtract(string $amount, string $subtrahend): string
     {
-        return bcsub($amount, $subtrahend, self::SCALE);
+        $scale = str_contains($amount, '.') || str_contains($subtrahend, '.') ? self::SCALE : 0;
+
+        return bcsub($amount, $subtrahend, $scale);
     }
 
     /** @psalm-pure */

--- a/src/Calculator/BcMathCalculator.php
+++ b/src/Calculator/BcMathCalculator.php
@@ -32,7 +32,7 @@ final class BcMathCalculator implements Calculator
     /** @psalm-pure */
     public static function add(string $amount, string $addend): string
     {
-        $scale = str_contains($amount, '.') || str_contains($addend, '.') ? self::SCALE : 0;
+        $scale = str_contains($amount . $addend, '.') ? self::SCALE : 0;
 
         return bcadd($amount, $addend, $scale);
     }
@@ -40,7 +40,7 @@ final class BcMathCalculator implements Calculator
     /** @psalm-pure */
     public static function subtract(string $amount, string $subtrahend): string
     {
-        $scale = str_contains($amount, '.') || str_contains($subtrahend, '.') ? self::SCALE : 0;
+        $scale = str_contains($amount . $subtrahend, '.') ? self::SCALE : 0;
 
         return bcsub($amount, $subtrahend, $scale);
     }


### PR DESCRIPTION
Optimize the result representation of some `BcMathCalculator` operations for faster usage in `\Money\Money::__construct`.

This will provide a 50% performance boost for some operations.

```
> vendor/bin/phpbench run --retry-threshold=3 --iterations=15 --revs=1000  --warmup=2 'benchmark/MoneyOperationBench.php' '--ref=before_bcmath_scale'
PHPBench (1.2.10) running benchmarks... #standwithukraine
with configuration file: /home/pushapidev/current/moneyphp/phpbench.json
with PHP version 8.1.17, xdebug ✔, opcache ✔
comparing [actual vs. before_bcmatch_scale]

\Benchmark\Money\MoneyOperationBench

    benchAdd................................R4 I9 - [Mo0.298μs vs. Mo0.610μs] -51.12% (±0.63%)
    benchSubtract...........................R1 I5 - [Mo0.298μs vs. Mo0.611μs] -51.34% (±1.04%)
    benchMultiply...........................R1 I12 - [Mo0.622μs vs. Mo0.629μs] -1.16% (±1.30%)
    benchDivide.............................R1 I13 - [Mo0.731μs vs. Mo0.726μs] +0.67% (±1.08%)
    benchSum................................R1 I12 - [Mo0.646μs vs. Mo1.063μs] -39.23% (±0.65%)
    benchMin................................R1 I14 - [Mo0.494μs vs. Mo0.493μs] +0.11% (±1.01%)
    benchMax................................R1 I6 - [Mo0.509μs vs. Mo0.512μs] -0.48% (±0.74%)
    benchAvg................................R1 I3 - [Mo1.462μs vs. Mo1.822μs] -19.79% (±1.40%)
    benchRatioOf............................R1 I0 - [Mo0.365μs vs. Mo0.349μs] +4.68% (±1.99%)
    benchMod................................R6 I13 - [Mo0.382μs vs. Mo0.383μs] -0.48% (±1.06%)
    benchIsSameCurrency.....................R1 I6 - [Mo0.059μs vs. Mo0.060μs] -1.88% (±1.31%)
    benchIsZero.............................R1 I11 - [Mo0.106μs vs. Mo0.105μs] +0.25% (±1.22%)
    benchAbsolute...........................R3 I14 - [Mo0.157μs vs. Mo0.157μs] -0.27% (±1.18%)
    benchNegative...........................R1 I9 - [Mo0.392μs vs. Mo0.710μs] -44.84% (±0.90%)
    benchIsPositive.........................R2 I6 - [Mo0.102μs vs. Mo0.102μs] -0.03% (±0.86%)
    benchCompare............................R3 I14 - [Mo0.133μs vs. Mo0.133μs] +0.06% (±0.98%)
    benchLessThan...........................R2 I3 - [Mo0.149μs vs. Mo0.149μs] -0.07% (±0.75%)
    benchLessThanOrEqual....................R2 I8 - [Mo0.149μs vs. Mo0.149μs] -0.01% (±1.25%)
    benchEquals.............................R1 I4 - [Mo0.169μs vs. Mo0.169μs] +0.13% (±0.93%)
    benchGreaterThan........................R1 I7 - [Mo0.149μs vs. Mo0.149μs] +0.11% (±1.60%)
    benchGreaterThanOrEqual.................R1 I14 - [Mo0.149μs vs. Mo0.149μs] +0.28% (±1.28%)

Subjects: 21, Assertions: 0, Failures: 0, Errors: 0
```

For full history: https://github.com/moneyphp/money/pull/747