### PR TITLE
Support (multiply|divide) for float numbers

### DIFF
--- a/src/Money.php
+++ b/src/Money.php
@@ -16,6 +16,7 @@ use function count;
 use function filter_var;
 use function floor;
 use function is_int;
+use function is_float;
 use function max;
 use function str_pad;
 use function strlen;
@@ -238,9 +239,9 @@ final class Money implements JsonSerializable
      * @psalm-param int|numeric-string $multiplier
      * @psalm-param self::ROUND_*  $roundingMode
      */
-    public function multiply(int|string $multiplier, int $roundingMode = self::ROUND_HALF_UP): Money
+    public function multiply(int|float|string $multiplier, int $roundingMode = self::ROUND_HALF_UP): Money
     {
-        if (is_int($multiplier)) {
+        if (is_int($multiplier) || is_float($multiplier)) {
             $multiplier = (string) $multiplier;
         }
 
@@ -256,9 +257,9 @@ final class Money implements JsonSerializable
      * @psalm-param int|numeric-string $divisor
      * @psalm-param self::ROUND_*  $roundingMode
      */
-    public function divide(int|string $divisor, int $roundingMode = self::ROUND_HALF_UP): Money
+    public function divide(int|float|string $divisor, int $roundingMode = self::ROUND_HALF_UP): Money
     {
-        if (is_int($divisor)) {
+        if (is_int($divisor) || is_float($divisor)) {
             $divisor = (string) $divisor;
         }
 


### PR DESCRIPTION
Hi team, we have a problem with multiplying or dividing by float numbers example:
```
$value = Money::EUR(800);       // €8.00
$result = $value->multiply(2.5);  // €16.00
```

Here it will just multiply by 2 only and ignore the float, but if we pass the number as a string it will work fine.
```
$value = Money::EUR(800);       // €8.00
$result = $value->multiply("2.5");  // €20.00
```

I'm using this package for a huge project and using multiply and divide functions a lot, this modification will help us to upgrade much more easily.
