### PR TITLE
tests: mark test as skippable if locale is not available

### DIFF
--- a/tests/MoneyTest.php
+++ b/tests/MoneyTest.php
@@ -99,11 +99,7 @@ final class MoneyTest extends TestCase
      */
     public function itMultipliesTheAmountWithLocaleThatUsesCommaSeparator(): void
     {
-        try {
-            $this->setLocale(LC_ALL, 'es_ES.utf8');
-        } catch (\Throwable) {
-            $this->markTestSkipped('The locale es_ES.utf8 is not available.');
-        }
+        $this->setLocale(LC_ALL, 'en_US.UTF-8');
 
         $money = new Money(100, new Currency(self::CURRENCY));
         $money = $money->multiply('0.1');

--- a/tests/MoneyTest.php
+++ b/tests/MoneyTest.php
@@ -99,7 +99,11 @@ final class MoneyTest extends TestCase
      */
     public function itMultipliesTheAmountWithLocaleThatUsesCommaSeparator(): void
     {
-        $this->setLocale(LC_ALL, 'es_ES.utf8');
+        try {
+            $this->setLocale(LC_ALL, 'es_ES.utf8');
+        } catch (\Throwable) {
+            $this->markTestSkipped('The locale es_ES.utf8 is not available.');
+        }
 
         $money = new Money(100, new Currency(self::CURRENCY));
         $money = $money->multiply('0.1');


### PR DESCRIPTION
This tests fails for me locally, because i do not have the locale installed.
I have to run tests one by one instead of `composer test`
With this change it makes it easier to test local.