### PR TITLE
feat: add un/serialize for currency

### DIFF
--- a/src/Currency.php
+++ b/src/Currency.php
@@ -67,7 +67,7 @@ final class Currency implements JsonSerializable, Serializable
         return ['code' => $this->code];
     }
 
-    # TODO Correct PSALM?
+    // TODO Correct PSALM?
     public function __unserialize(array $data): void
     {
         $this->code = (string) $data['code'];
@@ -81,9 +81,10 @@ final class Currency implements JsonSerializable, Serializable
         return $this->__serialize();
     }
 
-    # TODO Correct PSALM?
-    public function unserialize(string $data)
+    // TODO Correct PSALM?
+    // Correct CODE?
+    public function unserialize(string $data): void
     {
-        return $this->__unserialize($data);
+        $this->__unserialize((array) $data);
     }
 }

--- a/src/Currency.php
+++ b/src/Currency.php
@@ -57,4 +57,17 @@ final class Currency implements JsonSerializable
     {
         return $this->code;
     }
+
+    /**
+     * @return array<string, string>
+     */
+    public function __serialize(): array
+    {
+        return ['code' => $this->code];
+    }
+
+    public function __unserialize(array $data): void
+    {
+        $this->code = (string) $data['code'];
+    }
 }

--- a/src/Currency.php
+++ b/src/Currency.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Money;
 
 use JsonSerializable;
+use Serializable;
 
 use function strtoupper;
 
@@ -15,7 +16,7 @@ use function strtoupper;
  *
  * @psalm-immutable
  */
-final class Currency implements JsonSerializable
+final class Currency implements JsonSerializable, Serializable
 {
     /**
      * Currency code.
@@ -66,8 +67,23 @@ final class Currency implements JsonSerializable
         return ['code' => $this->code];
     }
 
+    # TODO Correct PSALM?
     public function __unserialize(array $data): void
     {
         $this->code = (string) $data['code'];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function serialize(): array
+    {
+        return $this->__serialize();
+    }
+
+    # TODO Correct PSALM?
+    public function unserialize(string $data)
+    {
+        return $this->__unserialize($data);
     }
 }


### PR DESCRIPTION
We use https://github.com/doctrine-extensions/DoctrineExtensions for Versioning.
I came across the problem, that versioning does not work for Curreny.
Symfony via https://github.com/TheBigBrainsCompany/TbbcMoneyBundle

We use this Attribut.

```
#[ORM\Column(options: ['default' => 'EUR'])]
#[Gedmo\Versioned]
public $currency = null;
```

```
public function setCurrency(Currency $currency): self
    {
        $this->currency = $currency;
        return $this;
    }

    public function getCurrency(): Currency
    {
        return new Currency($this->currency);
    }
```

This PR solves the problem for us.
But i am not sure if we use it, how it should be used.
Sideeffekts of this PR?