### PR TITLE
chore: psalm simplify positive-int|0 to non-negative-int (for tests)

### DIFF
--- a/tests/ConverterTest.php
+++ b/tests/ConverterTest.php
@@ -23,11 +23,11 @@ final class ConverterTest extends TestCase
     /**
      * @psalm-param non-empty-string $baseCurrencyCode
      * @psalm-param non-empty-string $counterCurrencyCode
-     * @psalm-param positive-int|0 $subunitBase
-     * @psalm-param positive-int|0 $subunitCounter
+     * @psalm-param non-negative-int $subunitBase
+     * @psalm-param non-negative-int $subunitCounter
      * @psalm-param int|float $ratio
      * @psalm-param positive-int|numeric-string $amount
-     * @psalm-param positive-int|0 $expectedAmount
+     * @psalm-param non-negative-int $expectedAmount
      *
      * @dataProvider convertExamples
      * @test
@@ -74,11 +74,11 @@ final class ConverterTest extends TestCase
     /**
      * @psalm-param non-empty-string $baseCurrencyCode
      * @psalm-param non-empty-string $counterCurrencyCode
-     * @psalm-param positive-int|0 $subunitBase
-     * @psalm-param positive-int|0 $subunitCounter
+     * @psalm-param non-negative-int $subunitBase
+     * @psalm-param non-negative-int $subunitCounter
      * @psalm-param int|float $ratio
      * @psalm-param positive-int|numeric-string $amount
-     * @psalm-param positive-int|0 $expectedAmount
+     * @psalm-param non-negative-int $expectedAmount
      *
      * @dataProvider convertExamples
      * @test
@@ -127,11 +127,11 @@ final class ConverterTest extends TestCase
     /**
      * @psalm-param non-empty-string $baseCurrencyCode
      * @psalm-param non-empty-string $counterCurrencyCode
-     * @psalm-param positive-int|0 $subunitBase
-     * @psalm-param positive-int|0 $subunitCounter
+     * @psalm-param non-negative-int $subunitBase
+     * @psalm-param non-negative-int $subunitCounter
      * @psalm-param int|float $ratio
      * @psalm-param positive-int|numeric-string $amount
-     * @psalm-param positive-int|0 $expectedAmount
+     * @psalm-param non-negative-int $expectedAmount
      *
      * @dataProvider convertExamples
      * @test
@@ -174,11 +174,11 @@ final class ConverterTest extends TestCase
     /**
      * @psalm-param non-empty-string $baseCurrencyCode
      * @psalm-param non-empty-string $counterCurrencyCode
-     * @psalm-param positive-int|0 $subunitBase
-     * @psalm-param positive-int|0 $subunitCounter
+     * @psalm-param non-negative-int $subunitBase
+     * @psalm-param non-negative-int $subunitCounter
      * @psalm-param int|float $ratio
      * @psalm-param positive-int|numeric-string $amount
-     * @psalm-param positive-int|0 $expectedAmount
+     * @psalm-param non-negative-int $expectedAmount
      *
      * @dataProvider convertExamples
      * @test
@@ -224,11 +224,11 @@ final class ConverterTest extends TestCase
      * @psalm-return non-empty-list<array{
      *     non-empty-string,
      *     non-empty-string,
-     *     positive-int|0,
-     *     positive-int|0,
+     *     non-negative-int,
+     *     non-negative-int,
      *     int|float,
      *     positive-int|numeric-string,
-     *     positive-int|0
+     *     non-negative-int
      * }>
      */
     public function convertExamples(): array

--- a/tests/Formatter/BitcoinMoneyFormatterTest.php
+++ b/tests/Formatter/BitcoinMoneyFormatterTest.php
@@ -16,7 +16,7 @@ final class BitcoinMoneyFormatterTest extends TestCase
     /**
      * @psalm-param positive-int $value
      * @psalm-param non-empty-string $formatted
-     * @psalm-param positive-int|0 $fractionDigits
+     * @psalm-param non-negative-int $fractionDigits
      *
      * @dataProvider bitcoinExamples
      * @test
@@ -41,7 +41,7 @@ final class BitcoinMoneyFormatterTest extends TestCase
      * @psalm-return non-empty-list<array{
      *     positive-int,
      *     non-empty-string,
-     *     positive-int|0
+     *     non-negative-int
      * }>
      */
     public function bitcoinExamples(): array

--- a/tests/Formatter/DecimalMoneyFormatterTest.php
+++ b/tests/Formatter/DecimalMoneyFormatterTest.php
@@ -15,7 +15,7 @@ final class DecimalMoneyFormatterTest extends TestCase
 {
     /**
      * @psalm-param non-empty-string $currency
-     * @psalm-param positive-int|0 $subunit
+     * @psalm-param non-negative-int $subunit
      * @psalm-param numeric-string $result
      *
      * @dataProvider moneyExamples
@@ -39,7 +39,7 @@ final class DecimalMoneyFormatterTest extends TestCase
      * @psalm-return non-empty-list<array{
      *     int,
      *     non-empty-string,
-     *     positive-int|0,
+     *     non-negative-int,
      *     numeric-string
      * }>
      */

--- a/tests/Formatter/IntlLocalizedDecimalFormatterTest.php
+++ b/tests/Formatter/IntlLocalizedDecimalFormatterTest.php
@@ -18,7 +18,7 @@ final class IntlLocalizedDecimalFormatterTest extends TestCase
      * @psalm-param non-empty-string $currency
      * @psalm-param positive-int $subunit
      * @psalm-param non-empty-string $result
-     * @psalm-param positive-int|0 $fractionDigits
+     * @psalm-param non-negative-int $fractionDigits
      *
      * @dataProvider moneyExamples
      * @test
@@ -48,7 +48,7 @@ final class IntlLocalizedDecimalFormatterTest extends TestCase
      *     positive-int,
      *     non-empty-string,
      *     int,
-     *     positive-int|0
+     *     non-negative-int
      * }>
      */
     public static function moneyExamples(): array

--- a/tests/Formatter/IntlMoneyFormatterTest.php
+++ b/tests/Formatter/IntlMoneyFormatterTest.php
@@ -19,7 +19,7 @@ final class IntlMoneyFormatterTest extends TestCase
      * @psalm-param positive-int $subunit
      * @psalm-param non-empty-string $result
      * @psalm-param positive-int $mode
-     * @psalm-param positive-int|0 $fractionDigits
+     * @psalm-param non-negative-int $fractionDigits
      *
      * @dataProvider moneyExamples
      * @test
@@ -54,7 +54,7 @@ final class IntlMoneyFormatterTest extends TestCase
      *     non-empty-string,
      *     positive-int,
      *     bool,
-     *     positive-int|0
+     *     non-negative-int
      * }>
      */
     public static function moneyExamples(): array

--- a/tests/MoneyTest.php
+++ b/tests/MoneyTest.php
@@ -131,7 +131,7 @@ final class MoneyTest extends TestCase
 
     /**
      * @psalm-param int $amount
-     * @psalm-param non-empty-array<positive-int|0|float> $ratios
+     * @psalm-param non-empty-array<non-negative-int|float> $ratios
      * @psalm-param non-empty-array<int> $results
      *
      * @dataProvider allocationExamples
@@ -208,7 +208,7 @@ final class MoneyTest extends TestCase
 
     /**
      * @psalm-param int|numeric-string $amount
-     * @psalm-param positive-int|0 $result
+     * @psalm-param non-negative-int $result
      *
      * @dataProvider absoluteExamples
      * @test
@@ -419,7 +419,7 @@ final class MoneyTest extends TestCase
 
     /**
      * @psalm-param int $amount
-     * @psalm-param positive-int|0 $unit
+     * @psalm-param non-negative-int $unit
      * @psalm-param int $expected
      * @psalm-param int $roundingMode
      *
@@ -487,7 +487,7 @@ final class MoneyTest extends TestCase
     /**
      * @psalm-return non-empty-list<array{
      *     int,
-     *     non-empty-array<int|string, positive-int|0|float>,
+     *     non-empty-array<int|string, non-negative-int|float>,
      *     non-empty-array<int|string, int>
      * }>
      */
@@ -554,7 +554,7 @@ final class MoneyTest extends TestCase
     /**
      * @psalm-return non-empty-list<array{
      *     int|numeric-string,
-     *     positive-int|0
+     *     non-negative-int
      * }>
      */
     public function absoluteExamples(): array
@@ -607,7 +607,7 @@ final class MoneyTest extends TestCase
     /**
      * @psalm-return non-empty-list<array{
      *     int,
-     *     positive-int|0,
+     *     non-negative-int,
      *     int,
      *     int
      * }>

--- a/tests/Parser/DecimalMoneyParserTest.php
+++ b/tests/Parser/DecimalMoneyParserTest.php
@@ -15,7 +15,7 @@ final class DecimalMoneyParserTest extends TestCase
 {
     /**
      * @psalm-param non-empty-string $currency
-     * @psalm-param positive-int|0 $subunit
+     * @psalm-param non-negative-int $subunit
      * @psalm-param int $result
      *
      * @dataProvider formattedMoneyExamples
@@ -58,7 +58,7 @@ final class DecimalMoneyParserTest extends TestCase
      * @psalm-return non-empty-list<array{
      *     string,
      *     non-empty-string,
-     *     positive-int|0,
+     *     non-negative-int,
      *     int
      * }>
      */


### PR DESCRIPTION
Should be the same. But with this Change PHPStorm accept it, as correct.
https://psalm.dev/docs/annotating_code/type_syntax/scalar_types/

For /tests/