### PR TITLE
chore: psalm simplify positive-int|0 to non-negative-int (for src)

### DIFF
--- a/src/Currencies/CryptoCurrencies.php
+++ b/src/Currencies/CryptoCurrencies.php
@@ -25,7 +25,7 @@ final class CryptoCurrencies implements Currencies
      *
      * @psalm-var non-empty-array<non-empty-string, array{
      *     symbol: non-empty-string,
-     *     minorUnit: positive-int|0
+     *     minorUnit: non-negative-int
      * }>|null
      */
     private static ?array $currencies = null;
@@ -64,7 +64,7 @@ final class CryptoCurrencies implements Currencies
      *
      * @psalm-return non-empty-array<non-empty-string, array{
      *     symbol: non-empty-string,
-     *     minorUnit: positive-int|0
+     *     minorUnit: non-negative-int
      * }>
      */
     private function getCurrencies(): array
@@ -79,7 +79,7 @@ final class CryptoCurrencies implements Currencies
     /**
      * @psalm-return non-empty-array<non-empty-string, array{
      *     symbol: non-empty-string,
-     *     minorUnit: positive-int|0
+     *     minorUnit: non-negative-int
      * }>
      */
     private function loadCurrencies(): array

--- a/src/Currencies/CurrencyList.php
+++ b/src/Currencies/CurrencyList.php
@@ -25,7 +25,7 @@ final class CurrencyList implements Currencies
      */
     private array $currencies;
 
-    /** @psalm-param array<non-empty-string, positive-int|0> $currencies */
+    /** @psalm-param array<non-empty-string, non-negative-int> $currencies */
     public function __construct(array $currencies)
     {
         $this->currencies = $currencies;

--- a/src/Currencies/ISOCurrencies.php
+++ b/src/Currencies/ISOCurrencies.php
@@ -26,7 +26,7 @@ final class ISOCurrencies implements Currencies
      * @psalm-var non-empty-array<non-empty-string, array{
      *     alphabeticCode: non-empty-string,
      *     currency: non-empty-string,
-     *     minorUnit: positive-int|0,
+     *     minorUnit: non-negative-int,
      *     numericCode: positive-int
      * }>|null
      */
@@ -81,7 +81,7 @@ final class ISOCurrencies implements Currencies
      * @psalm-return non-empty-array<non-empty-string, array{
      *     alphabeticCode: non-empty-string,
      *     currency: non-empty-string,
-     *     minorUnit: positive-int|0,
+     *     minorUnit: non-negative-int,
      *     numericCode: positive-int
      * }>
      */
@@ -98,7 +98,7 @@ final class ISOCurrencies implements Currencies
      * @psalm-return non-empty-array<non-empty-string, array{
      *     alphabeticCode: non-empty-string,
      *     currency: non-empty-string,
-     *     minorUnit: positive-int|0,
+     *     minorUnit: non-negative-int,
      *     numericCode: positive-int
      * }>
      */

--- a/src/Money.php
+++ b/src/Money.php
@@ -399,7 +399,7 @@ final class Money implements JsonSerializable
     /**
      * Round to a specific unit.
      *
-     * @psalm-param positive-int|0  $unit
+     * @psalm-param non-negative-int  $unit
      * @psalm-param self::ROUND_* $roundingMode
      */
     public function roundToUnit(int $unit, int $roundingMode = self::ROUND_HALF_UP): self

--- a/src/Number.php
+++ b/src/Number.php
@@ -264,7 +264,7 @@ final class Number
 
         if ($shouldRound && $moneyValue[$valueLength - $havingDigits + $targetDigits] >= 5) {
             $position = $valueLength - $havingDigits + $targetDigits;
-            /** @psalm-var positive-int|0 $addend */
+            /** @psalm-var non-negative-int $addend */
             $addend = 1;
 
             while ($position > 0) {


### PR DESCRIPTION
Same as https://github.com/moneyphp/money/pull/781
but for /src.

I did split it up, because i do not know at which version of psalm it was added.
And maybe has effects on userland projects with lower psalm version?
https://github.com/vimeo/psalm/issues/7769