### PR TITLE
upgrade doctrine/coding-standard to version 12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "ext-gmp": "*",
         "ext-intl": "*",
         "cache/taggable-cache": "^1.1.0",
-        "doctrine/coding-standard": "^9.0",
+        "doctrine/coding-standard": "^12.0",
         "doctrine/instantiator": "^1.5.0 || ^2.0",
         "florianv/exchanger": "^2.8.1",
         "florianv/swap": "^4.3.0",

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -28,5 +28,12 @@
         <!-- language-level non-strict comparison is (consciously) used in the codebase for performance reasons -->
         <exclude name="SlevomatCodingStandard.Operators.DisallowEqualOperators.DisallowedEqualOperator"/>
         <exclude name="SlevomatCodingStandard.Operators.DisallowEqualOperators.DisallowedNotEqualOperator"/>
+
+        <!-- We do not want trailing commas -->
+        <exclude name="SlevomatCodingStandard.Commenting.RequireOneLineDocComment"/>
+        <exclude name="SlevomatCodingStandard.Functions.RequireTrailingCommaInCall"/>
+        <exclude name="SlevomatCodingStandard.Functions.RequireTrailingCommaInClosureUse"/>
+        <exclude name="SlevomatCodingStandard.Functions.RequireTrailingCommaInDeclaration"/>
+        <exclude name="SlevomatCodingStandard.Arrays.TrailingArrayComma"/>
     </rule>
 </ruleset>

--- a/src/Converter.php
+++ b/src/Converter.php
@@ -13,14 +13,8 @@ use function sprintf;
  */
 final class Converter
 {
-    private Currencies $currencies;
-
-    private Exchange $exchange;
-
-    public function __construct(Currencies $currencies, Exchange $exchange)
+    public function __construct(private readonly Currencies $currencies, private readonly Exchange $exchange)
     {
-        $this->currencies = $currencies;
-        $this->exchange   = $exchange;
     }
 
     public function convert(Money $money, Currency $counterCurrency, int $roundingMode = Money::ROUND_HALF_UP): Money

--- a/src/Currencies/AggregateCurrencies.php
+++ b/src/Currencies/AggregateCurrencies.php
@@ -15,15 +15,11 @@ use Traversable;
  */
 final class AggregateCurrencies implements Currencies
 {
-    /** @var Currencies[] */
-    private array $currencies;
-
     /**
      * @param Currencies[] $currencies
      */
-    public function __construct(array $currencies)
+    public function __construct(private readonly array $currencies)
     {
-        $this->currencies = $currencies;
     }
 
     public function contains(Currency $currency): bool

--- a/src/Currencies/CachedCurrencies.php
+++ b/src/Currencies/CachedCurrencies.php
@@ -19,14 +19,8 @@ use function iterator_to_array;
  */
 final class CachedCurrencies implements Currencies
 {
-    private Currencies $currencies;
-
-    private CacheItemPoolInterface $pool;
-
-    public function __construct(Currencies $currencies, CacheItemPoolInterface $pool)
+    public function __construct(private readonly Currencies $currencies, private readonly CacheItemPoolInterface $pool)
     {
-        $this->currencies = $currencies;
-        $this->pool       = $pool;
     }
 
     public function contains(Currency $currency): bool

--- a/src/Currencies/CryptoCurrencies.php
+++ b/src/Currencies/CryptoCurrencies.php
@@ -28,7 +28,7 @@ final class CryptoCurrencies implements Currencies
      *     minorUnit: non-negative-int
      * }>|null
      */
-    private static ?array $currencies = null;
+    private static array|null $currencies = null;
 
     public function contains(Currency $currency): bool
     {

--- a/src/Currencies/ISOCurrencies.php
+++ b/src/Currencies/ISOCurrencies.php
@@ -30,7 +30,7 @@ final class ISOCurrencies implements Currencies
      *     numericCode: positive-int
      * }>|null
      */
-    private static ?array $currencies = null;
+    private static array|null $currencies = null;
 
     public function contains(Currency $currency): bool
     {

--- a/src/CurrencyPair.php
+++ b/src/CurrencyPair.php
@@ -20,26 +20,13 @@ use function sprintf;
 final class CurrencyPair implements JsonSerializable
 {
     /**
-     * Currency to convert from.
-     */
-    private Currency $baseCurrency;
-
-    /**
-     * Currency to convert to.
-     */
-    private Currency $counterCurrency;
-
-    /** @psalm-var numeric-string */
-    private string $conversionRatio;
-
-    /**
      * @psalm-param numeric-string $conversionRatio
      */
-    public function __construct(Currency $baseCurrency, Currency $counterCurrency, string $conversionRatio)
-    {
-        $this->counterCurrency = $counterCurrency;
-        $this->baseCurrency    = $baseCurrency;
-        $this->conversionRatio = $conversionRatio;
+    public function __construct(
+        private readonly Currency $baseCurrency,
+        private readonly Currency $counterCurrency,
+        private readonly string $conversionRatio
+    ) {
     }
 
     /**
@@ -95,7 +82,7 @@ final class CurrencyPair implements JsonSerializable
     }
 
     /**
-     * Checks if an other CurrencyPair has the same parameters as this.
+     * Checks if another CurrencyPair has the same parameters as this.
      */
     public function equals(CurrencyPair $other): bool
     {
@@ -105,7 +92,7 @@ final class CurrencyPair implements JsonSerializable
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      *
      * @psalm-return array{baseCurrency: Currency, counterCurrency: Currency, ratio: numeric-string}
      */

--- a/src/Exchange/ExchangerExchange.php
+++ b/src/Exchange/ExchangerExchange.php
@@ -22,11 +22,8 @@ use function sprintf;
  */
 final class ExchangerExchange implements Exchange
 {
-    private ExchangeRateProvider $exchanger;
-
-    public function __construct(ExchangeRateProvider $exchanger)
+    public function __construct(private readonly ExchangeRateProvider $exchanger)
     {
-        $this->exchanger = $exchanger;
     }
 
     public function quote(Currency $baseCurrency, Currency $counterCurrency): CurrencyPair

--- a/src/Exchange/FixedExchange.php
+++ b/src/Exchange/FixedExchange.php
@@ -14,13 +14,9 @@ use Money\Exchange;
  */
 final class FixedExchange implements Exchange
 {
-    /** @psalm-var array<non-empty-string, array<non-empty-string, numeric-string>> */
-    private array $list;
-
     /** @psalm-param array<non-empty-string, array<non-empty-string, numeric-string>> $list */
-    public function __construct(array $list)
+    public function __construct(private readonly array $list)
     {
-        $this->list = $list;
     }
 
     public function quote(Currency $baseCurrency, Currency $counterCurrency): CurrencyPair

--- a/src/Exchange/IndirectExchange.php
+++ b/src/Exchange/IndirectExchange.php
@@ -20,14 +20,8 @@ use function array_reverse;
  */
 final class IndirectExchange implements Exchange
 {
-    private Currencies $currencies;
-
-    private Exchange $exchange;
-
-    public function __construct(Exchange $exchange, Currencies $currencies)
+    public function __construct(private readonly Exchange $exchange, private readonly Currencies $currencies)
     {
-        $this->exchange   = $exchange;
-        $this->currencies = $currencies;
     }
 
     public function quote(Currency $baseCurrency, Currency $counterCurrency): CurrencyPair
@@ -99,7 +93,7 @@ final class IndirectExchange implements Exchange
                     $node->parent     = $currentNode;
 
                     $frontier->enqueue($node);
-                } catch (UnresolvableCurrencyPairException $exception) {
+                } catch (UnresolvableCurrencyPairException) {
                     // Not a neighbor. Move on.
                 }
             }

--- a/src/Exchange/IndirectExchangeQueuedItem.php
+++ b/src/Exchange/IndirectExchangeQueuedItem.php
@@ -9,12 +9,10 @@ use Money\Currency;
 /** @internal for sole consumption by {@see IndirectExchange} */
 final class IndirectExchangeQueuedItem
 {
-    public Currency $currency;
-    public bool $discovered = false;
-    public ?self $parent    = null;
+    public bool $discovered  = false;
+    public self|null $parent = null;
 
-    public function __construct(Currency $currency)
+    public function __construct(public Currency $currency)
     {
-        $this->currency = $currency;
     }
 }

--- a/src/Exchange/ReversedCurrenciesExchange.php
+++ b/src/Exchange/ReversedCurrenciesExchange.php
@@ -17,11 +17,8 @@ use Money\Money;
  */
 final class ReversedCurrenciesExchange implements Exchange
 {
-    private Exchange $exchange;
-
-    public function __construct(Exchange $exchange)
+    public function __construct(private readonly Exchange $exchange)
     {
-        $this->exchange = $exchange;
     }
 
     public function quote(Currency $baseCurrency, Currency $counterCurrency): CurrencyPair

--- a/src/Exchange/SwapExchange.php
+++ b/src/Exchange/SwapExchange.php
@@ -20,11 +20,8 @@ use function sprintf;
  */
 final class SwapExchange implements Exchange
 {
-    private Swap $swap;
-
-    public function __construct(Swap $swap)
+    public function __construct(private readonly Swap $swap)
     {
-        $this->swap = $swap;
     }
 
     public function quote(Currency $baseCurrency, Currency $counterCurrency): CurrencyPair

--- a/src/Formatter/BitcoinMoneyFormatter.php
+++ b/src/Formatter/BitcoinMoneyFormatter.php
@@ -21,14 +21,8 @@ use function substr;
  */
 final class BitcoinMoneyFormatter implements MoneyFormatter
 {
-    private int $fractionDigits;
-
-    private Currencies $currencies;
-
-    public function __construct(int $fractionDigits, Currencies $currencies)
+    public function __construct(private readonly int $fractionDigits, private readonly Currencies $currencies)
     {
-        $this->fractionDigits = $fractionDigits;
-        $this->currencies     = $currencies;
     }
 
     public function format(Money $money): string

--- a/src/Formatter/DecimalMoneyFormatter.php
+++ b/src/Formatter/DecimalMoneyFormatter.php
@@ -18,11 +18,8 @@ use function substr;
  */
 final class DecimalMoneyFormatter implements MoneyFormatter
 {
-    private Currencies $currencies;
-
-    public function __construct(Currencies $currencies)
+    public function __construct(private readonly Currencies $currencies)
     {
-        $this->currencies = $currencies;
     }
 
     /** @psalm-return numeric-string */

--- a/src/Formatter/IntlLocalizedDecimalFormatter.php
+++ b/src/Formatter/IntlLocalizedDecimalFormatter.php
@@ -20,14 +20,8 @@ use function substr;
  */
 final class IntlLocalizedDecimalFormatter implements MoneyFormatter
 {
-    private NumberFormatter $formatter;
-
-    private Currencies $currencies;
-
-    public function __construct(NumberFormatter $formatter, Currencies $currencies)
+    public function __construct(private readonly NumberFormatter $formatter, private readonly Currencies $currencies)
     {
-        $this->formatter  = $formatter;
-        $this->currencies = $currencies;
     }
 
     public function format(Money $money): string

--- a/src/Formatter/IntlMoneyFormatter.php
+++ b/src/Formatter/IntlMoneyFormatter.php
@@ -19,14 +19,8 @@ use function substr;
  */
 final class IntlMoneyFormatter implements MoneyFormatter
 {
-    private NumberFormatter $formatter;
-
-    private Currencies $currencies;
-
-    public function __construct(NumberFormatter $formatter, Currencies $currencies)
+    public function __construct(private readonly NumberFormatter $formatter, private readonly Currencies $currencies)
     {
-        $this->formatter  = $formatter;
-        $this->currencies = $currencies;
     }
 
     public function format(Money $money): string

--- a/src/Money.php
+++ b/src/Money.php
@@ -59,8 +59,6 @@ final class Money implements JsonSerializable
      */
     private string $amount;
 
-    private Currency $currency;
-
     /**
      * @var Calculator
      * @psalm-var class-string<Calculator>
@@ -73,10 +71,8 @@ final class Money implements JsonSerializable
      *
      * @throws InvalidArgumentException If amount is not integer(ish).
      */
-    public function __construct(int|string $amount, Currency $currency)
+    public function __construct(int|string $amount, private readonly Currency $currency)
     {
-        $this->currency = $currency;
-
         if (filter_var($amount, FILTER_VALIDATE_INT) === false) {
             $numberFromString = Number::fromString((string) $amount);
             if (! $numberFromString->isInteger()) {
@@ -464,7 +460,7 @@ final class Money implements JsonSerializable
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      *
      * @psalm-return array{amount: string, currency: string}
      */

--- a/src/Parser/AggregateMoneyParser.php
+++ b/src/Parser/AggregateMoneyParser.php
@@ -17,18 +17,11 @@ use function sprintf;
 final class AggregateMoneyParser implements MoneyParser
 {
     /**
-     * @var MoneyParser[]
-     * @psalm-var non-empty-array<MoneyParser>
-     */
-    private array $parsers;
-
-    /**
      * @param MoneyParser[] $parsers
      * @psalm-param non-empty-array<MoneyParser> $parsers
      */
-    public function __construct(array $parsers)
+    public function __construct(private readonly array $parsers)
     {
-        $this->parsers = $parsers;
     }
 
     public function parse(string $money, Currency|null $fallbackCurrency = null): Money
@@ -36,7 +29,7 @@ final class AggregateMoneyParser implements MoneyParser
         foreach ($this->parsers as $parser) {
             try {
                 return $parser->parse($money, $fallbackCurrency);
-            } catch (Exception\ParserException $e) {
+            } catch (Exception\ParserException) {
             }
         }
 

--- a/src/Parser/BitcoinMoneyParser.php
+++ b/src/Parser/BitcoinMoneyParser.php
@@ -23,11 +23,8 @@ use function substr;
  */
 final class BitcoinMoneyParser implements MoneyParser
 {
-    private int $fractionDigits;
-
-    public function __construct(int $fractionDigits)
+    public function __construct(private readonly int $fractionDigits)
     {
-        $this->fractionDigits = $fractionDigits;
     }
 
     public function parse(string $money, Currency|null $fallbackCurrency = null): Money

--- a/src/Parser/DecimalMoneyParser.php
+++ b/src/Parser/DecimalMoneyParser.php
@@ -26,11 +26,8 @@ final class DecimalMoneyParser implements MoneyParser
 {
     public const DECIMAL_PATTERN = '/^(?P<sign>-)?(?P<digits>\d+)?\.?(?P<fraction>\d+)?$/';
 
-    private Currencies $currencies;
-
-    public function __construct(Currencies $currencies)
+    public function __construct(private readonly Currencies $currencies)
     {
-        $this->currencies = $currencies;
     }
 
     public function parse(string $money, Currency|null $fallbackCurrency = null): Money

--- a/src/Parser/IntlLocalizedDecimalParser.php
+++ b/src/Parser/IntlLocalizedDecimalParser.php
@@ -24,14 +24,8 @@ use function substr;
  */
 final class IntlLocalizedDecimalParser implements MoneyParser
 {
-    private NumberFormatter $formatter;
-
-    private Currencies $currencies;
-
-    public function __construct(NumberFormatter $formatter, Currencies $currencies)
+    public function __construct(private readonly NumberFormatter $formatter, private readonly Currencies $currencies)
     {
-        $this->formatter  = $formatter;
-        $this->currencies = $currencies;
     }
 
     public function parse(string $money, Currency|null $fallbackCurrency = null): Money

--- a/src/Parser/IntlMoneyParser.php
+++ b/src/Parser/IntlMoneyParser.php
@@ -25,14 +25,8 @@ use function substr;
  */
 final class IntlMoneyParser implements MoneyParser
 {
-    private NumberFormatter $formatter;
-
-    private Currencies $currencies;
-
-    public function __construct(NumberFormatter $formatter, Currencies $currencies)
+    public function __construct(private readonly NumberFormatter $formatter, private readonly Currencies $currencies)
     {
-        $this->formatter  = $formatter;
-        $this->currencies = $currencies;
     }
 
     public function parse(string $money, Currency|null $fallbackCurrency = null): Money

--- a/src/Teller.php
+++ b/src/Teller.php
@@ -43,24 +43,12 @@ final class Teller
         );
     }
 
-    private Currency $currency;
-
-    private MoneyFormatter $formatter;
-
-    private MoneyParser $parser;
-
-    private int $roundingMode = Money::ROUND_HALF_UP;
-
     public function __construct(
-        Currency $currency,
-        MoneyParser $parser,
-        MoneyFormatter $formatter,
-        int $roundingMode = Money::ROUND_HALF_UP
+        private readonly Currency $currency,
+        private readonly MoneyParser $parser,
+        private readonly MoneyFormatter $formatter,
+        private readonly int $roundingMode = Money::ROUND_HALF_UP
     ) {
-        $this->currency     = $currency;
-        $this->parser       = $parser;
-        $this->formatter    = $formatter;
-        $this->roundingMode = $roundingMode;
     }
 
     /**

--- a/tests/Parser/DecimalMoneyParserTest.php
+++ b/tests/Parser/DecimalMoneyParserTest.php
@@ -45,7 +45,7 @@ final class DecimalMoneyParserTest extends TestCase
         $currencies = $this->createMock(Currencies::class);
 
         $currencies->method('subunitFor')
-            ->with(self::callback(static fn (Currency $givenCurrency): bool => 'USD' === $givenCurrency->getCode()))
+            ->with(self::callback(static fn (Currency $givenCurrency): bool => $givenCurrency->getCode() === 'USD'))
             ->willReturn(2);
 
         $parser = new DecimalMoneyParser($currencies);

--- a/tests/Parser/IntlLocalizedDecimalParserTest.php
+++ b/tests/Parser/IntlLocalizedDecimalParserTest.php
@@ -30,7 +30,7 @@ final class IntlLocalizedDecimalParserTest extends TestCase
         $currencies = $this->createMock(Currencies::class);
 
         $currencies->method('subunitFor')
-            ->with(self::callback(static fn (Currency $givenCurrency): bool => 'USD' === $givenCurrency->getCode()))
+            ->with(self::callback(static fn (Currency $givenCurrency): bool => $givenCurrency->getCode() === 'USD'))
             ->willReturn(2);
 
         $currencyCode = 'USD';

--- a/tests/Parser/IntlMoneyParserTest.php
+++ b/tests/Parser/IntlMoneyParserTest.php
@@ -30,7 +30,7 @@ final class IntlMoneyParserTest extends TestCase
         $currencies = $this->createMock(Currencies::class);
 
         $currencies->method('subunitFor')
-            ->with(self::callback(static fn (Currency $givenCurrency): bool => 'USD' === $givenCurrency->getCode()))
+            ->with(self::callback(static fn (Currency $givenCurrency): bool => $givenCurrency->getCode() === 'USD'))
             ->willReturn(2);
 
         $currencyCode = 'USD';


### PR DESCRIPTION
upgrade doctrine/coding-standard to version 12:
- we do not want trailing comma's
- do not require one line doc comment
- but we do want property promotion