### PR TITLE
Allow PHP 8.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     ],
     "homepage": "http://moneyphp.org",
     "require": {
-        "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
+        "php": "^8.1",
         "ext-bcmath": "*",
         "ext-filter": "*",
         "ext-json": "*"


### PR DESCRIPTION
I don’t get it why this library forcefully disallows installation on higher / unsupported PHP versions.

It’s one of the few dependencies that I know that do this. 

Can we please relax this so that people can start running their CI on PHP 8.4 already to spot issues and report / fix them here.