### PR TITLE
Add PHP 8.4 to test matrix

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,38 @@
+name: Benchmark
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  tests:
+    name: Build
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php:
+          - '8.1'
+          - '8.2'
+          - '8.3'
+          - '8.4'
+
+    steps:
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: bcmath, gmp, intl, dom, mbstring
+          ini-values: zend.assertions=1
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Remove Psalm when on PHP 8.4
+        if: ${{ matrix.php == '8.4' }}
+        run: composer remove --dev psalm/plugin-phpunit vimeo/psalm
+
+      - uses: "ramsey/composer-install@v3"
+
+      - name: Run phpbench
+        run: vendor/bin/phpbench run

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.3'
           extensions: bcmath, gmp, intl, dom, mbstring
 
       - uses: "ramsey/composer-install@v3"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         php:
           - '8.1'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,9 @@ jobs:
       - name: Set up locales
         run: ./hack/setup-locales.sh
 
-      - name: Download dependencies
-        run: composer update --prefer-stable --prefer-dist --no-interaction --no-progress --no-suggest --prefer-lowest --classmap-authoritative
+      - uses: "ramsey/composer-install@v3"
+        with:
+          dependency-versions: "lowest"
 
       - name: Run tests
         run: composer test
@@ -58,8 +59,7 @@ jobs:
       - name: Set up locales
         run: ./hack/setup-locales.sh
 
-      - name: Download dependencies
-        run: composer install --classmap-authoritative
+      - uses: "ramsey/composer-install@v3"
 
       - name: Run tests
         run: composer test
@@ -78,8 +78,7 @@ jobs:
           php-version: '8.1'
           extensions: bcmath, gmp, intl, dom, mbstring
 
-      - name: Download dependencies
-        run: composer install --classmap-authoritative
+      - uses: "ramsey/composer-install@v3"
 
       - name: Psalm
         run: vendor/bin/psalm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
       - uses: "ramsey/composer-install@v3"
 
       - name: Run tests
-        run: composer test
+        run: vendor/bin/phpunit
 
   psalm:
     name: Psalm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ jobs:
           - '8.1'
           - '8.2'
           - '8.3'
+          - '8.4'
 
     steps:
       - name: Set up PHP
@@ -58,6 +59,10 @@ jobs:
 
       - name: Set up locales
         run: ./hack/setup-locales.sh
+
+      - name: Remove Psalm when on PHP 8.4
+        if: ${{ matrix.php == '8.4' }}
+        run: composer remove --dev psalm/plugin-phpunit vimeo/psalm
 
       - uses: "ramsey/composer-install@v3"
 

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.3'
           extensions: bcmath, gmp, intl, dom, mbstring
 
       - name: Download dependencies

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     ],
     "homepage": "http://moneyphp.org",
     "require": {
-        "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
+        "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
         "ext-bcmath": "*",
         "ext-filter": "*",
         "ext-json": "*"


### PR DESCRIPTION
I don’t get it why this library forcefully disallows installation on higher / unsupported PHP versions.

It’s one of the few dependencies that I know that do this. 

Can we please relax this so that people can start running their CI on PHP 8.4 already to spot issues and report / fix them here.

Added PHP 8.4 to the test matrix, and it just works fine. 

These need to be merged and tagged too:
- https://github.com/moneyphp/crypto-currencies/pull/11
- https://github.com/moneyphp/iso-currencies/pull/18