### PR TITLE
feat: allow PHP 8.4, temp remove Vimeo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,9 @@ jobs:
       - name: Set up locales
         run: ./hack/setup-locales.sh
 
-      - name: Download dependencies
-        run: composer update --prefer-stable --prefer-dist --no-interaction --no-progress --no-suggest --prefer-lowest --classmap-authoritative
+      - uses: "ramsey/composer-install@v3"
+        with:
+          dependency-versions: "lowest"
 
       - name: Run tests
         run: composer test
@@ -40,6 +41,7 @@ jobs:
           - '8.1'
           - '8.2'
           - '8.3'
+          - '8.4'
 
     steps:
       - name: Set up PHP
@@ -58,8 +60,7 @@ jobs:
       - name: Set up locales
         run: ./hack/setup-locales.sh
 
-      - name: Download dependencies
-        run: composer install --classmap-authoritative
+      - uses: "ramsey/composer-install@v3"
 
       - name: Run tests
         run: composer test
@@ -78,11 +79,7 @@ jobs:
           php-version: '8.1'
           extensions: bcmath, gmp, intl, dom, mbstring
 
-      - name: Download dependencies
-        run: composer install --classmap-authoritative
-
-      - name: Psalm
-        run: vendor/bin/psalm
+      - uses: "ramsey/composer-install@v3"
 
   docs:
     name: Docs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,21 +65,7 @@ jobs:
       - name: Run tests
         run: composer test
 
-  psalm:
-    name: Psalm
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Set up PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: '8.1'
-          extensions: bcmath, gmp, intl, dom, mbstring
-
-      - uses: "ramsey/composer-install@v3"
+  # TODO re-Add psalm or PHPStan
 
   docs:
     name: Docs

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     ],
     "homepage": "http://moneyphp.org",
     "require": {
-        "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
+        "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
         "ext-bcmath": "*",
         "ext-filter": "*",
         "ext-json": "*"
@@ -43,9 +43,7 @@
         "php-http/mock-client": "^1.6.0",
         "phpbench/phpbench": "^1.2.5",
         "phpunit/phpunit": "^10.5.9",
-        "psalm/plugin-phpunit": "^0.18.4",
-        "psr/cache": "^1.0.1 || ^2.0 || ^3.0",
-        "vimeo/psalm": "~5.20.0"
+        "psr/cache": "^1.0.1 || ^2.0 || ^3.0"
     },
     "suggest": {
         "ext-gmp": "Calculate without integer limits",
@@ -90,7 +88,6 @@
         "test": [
             "vendor/bin/phpbench run",
             "vendor/bin/phpunit",
-            "vendor/bin/psalm",
             "vendor/bin/phpcs"
         ],
         "test-coverage": [


### PR DESCRIPTION
https://github.com/moneyphp/money/pull/796

@ruudk @frederikbosch 
Could you please have a look if this is a solution for a pre-release to help People to move on with PHP 8.4 ?


There is one Deprecation about a vendor-library. but this needs to be fixed there.
1) ...money/vendor/florianv/swap/src/Swap.php:80
Swap\Swap::quote(): Implicitly marking parameter $date as nullable is deprecated, the explicit nullable type must be used instead