### PR TITLE
Introduce subtypes of InvalidArgumentException

### DIFF
--- a/src/Exception/CurrencyMismatchException.php
+++ b/src/Exception/CurrencyMismatchException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Money\Exception;
+
+final class CurrencyMismatchException extends InvalidArgumentException
+{
+}

--- a/src/Exception/CurrencyMismatchException.php
+++ b/src/Exception/CurrencyMismatchException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Money\Exception;
 
 final class CurrencyMismatchException extends InvalidArgumentException

--- a/src/Exception/DivisionByZeroException.php
+++ b/src/Exception/DivisionByZeroException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Money\Exception;
 
 final class DivisionByZeroException extends InvalidArgumentException

--- a/src/Exception/DivisionByZeroException.php
+++ b/src/Exception/DivisionByZeroException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Money\Exception;
+
+final class DivisionByZeroException extends InvalidArgumentException
+{
+}

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -7,17 +7,26 @@ namespace Money\Exception;
 use InvalidArgumentException as CoreInvalidArgumentException;
 use Money\Exception;
 
-final class InvalidArgumentException extends CoreInvalidArgumentException implements Exception
+/**
+ * @internal
+ */
+class InvalidArgumentException extends CoreInvalidArgumentException implements Exception
 {
     /** @phpstan-pure */
-    public static function divisionByZero(): self
+    public static function divisionByZero(): DivisionByZeroException
     {
-        return new self('Cannot compute division with a zero divisor');
+        return new DivisionByZeroException('Cannot compute division with a zero divisor');
     }
 
     /** @phpstan-pure */
-    public static function moduloByZero(): self
+    public static function moduloByZero(): ModuleByZeroException
     {
-        return new self('Cannot compute modulo with a zero divisor');
+        return new ModuleByZeroException('Cannot compute modulo with a zero divisor');
+    }
+
+    /** @phpstan-pure */
+    public static function currencyMismatch(): CurrencyMismatchException
+    {
+        return new CurrencyMismatchException('Currencies must be identical');
     }
 }

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -19,9 +19,9 @@ class InvalidArgumentException extends CoreInvalidArgumentException implements E
     }
 
     /** @phpstan-pure */
-    public static function moduloByZero(): ModuleByZeroException
+    public static function moduloByZero(): ModuloByZeroException
     {
-        return new ModuleByZeroException('Cannot compute modulo with a zero divisor');
+        return new ModuloByZeroException('Cannot compute modulo with a zero divisor');
     }
 
     /** @phpstan-pure */

--- a/src/Exception/ModuleByZeroException.php
+++ b/src/Exception/ModuleByZeroException.php
@@ -1,7 +1,0 @@
-<?php
-
-namespace Money\Exception;
-
-final class ModuleByZeroException extends InvalidArgumentException
-{
-}

--- a/src/Exception/ModuleByZeroException.php
+++ b/src/Exception/ModuleByZeroException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Money\Exception;
+
+final class ModuleByZeroException extends InvalidArgumentException
+{
+}

--- a/src/Exception/ModuloByZeroException.php
+++ b/src/Exception/ModuloByZeroException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Money\Exception;
 
 final class ModuloByZeroException extends InvalidArgumentException

--- a/src/Exception/ModuloByZeroException.php
+++ b/src/Exception/ModuloByZeroException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Money\Exception;
+
+final class ModuloByZeroException extends InvalidArgumentException
+{
+}

--- a/src/Money.php
+++ b/src/Money.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Money;
 
-use InvalidArgumentException;
 use JsonSerializable;
 use Money\Calculator\BcMathCalculator;
+use Money\Exception\InvalidArgumentException;
 
 use function array_fill;
 use function array_keys;
@@ -135,7 +135,7 @@ final class Money implements JsonSerializable
     {
         // Note: non-strict equality is intentional here, since `Currency` is `final` and reliable.
         if ($this->currency != $other->currency) {
-            throw new InvalidArgumentException('Currencies must be identical');
+            throw InvalidArgumentException::currencyMismatch();
         }
 
         // @phpstan-ignore impure.staticPropertyAccess, possiblyImpure.methodCall
@@ -209,7 +209,7 @@ final class Money implements JsonSerializable
         foreach ($addends as $addend) {
             // Note: non-strict equality is intentional here, since `Currency` is `final` and reliable.
             if ($this->currency != $addend->currency) {
-                throw new InvalidArgumentException('Currencies must be identical');
+                throw InvalidArgumentException::currencyMismatch();
             }
 
             // @phpstan-ignore impure.staticPropertyAccess, possiblyImpure.methodCall
@@ -232,7 +232,7 @@ final class Money implements JsonSerializable
         foreach ($subtrahends as $subtrahend) {
             // Note: non-strict equality is intentional here, since `Currency` is `final` and reliable.
             if ($this->currency != $subtrahend->currency) {
-                throw new InvalidArgumentException('Currencies must be identical');
+                throw InvalidArgumentException::currencyMismatch();
             }
 
             // @phpstan-ignore impure.staticPropertyAccess, possiblyImpure.methodCall
@@ -291,7 +291,7 @@ final class Money implements JsonSerializable
         if ($divisor instanceof self) {
             // Note: non-strict equality is intentional here, since `Currency` is `final` and reliable.
             if ($this->currency != $divisor->currency) {
-                throw new InvalidArgumentException('Currencies must be identical');
+                throw InvalidArgumentException::currencyMismatch();
             }
 
             $divisor = $divisor->amount;
@@ -385,7 +385,7 @@ final class Money implements JsonSerializable
 
         // Note: non-strict equality is intentional here, since `Currency` is `final` and reliable.
         if ($this->currency != $money->currency) {
-            throw new InvalidArgumentException('Currencies must be identical');
+            throw InvalidArgumentException::currencyMismatch();
         }
 
         return self::$calculator::divide($this->amount, $money->amount);

--- a/tests/MoneyTest.php
+++ b/tests/MoneyTest.php
@@ -6,6 +6,7 @@ namespace Tests\Money;
 
 use InvalidArgumentException;
 use Money\Currency;
+use Money\Exception\CurrencyMismatchException;
 use Money\Money;
 use PHPUnit\Framework\TestCase;
 
@@ -294,7 +295,7 @@ final class MoneyTest extends TestCase
         $money      = new Money(self::AMOUNT, new Currency(self::CURRENCY));
         $rightMoney = new Money(self::OTHER_AMOUNT, new Currency(self::OTHER_CURRENCY));
 
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(CurrencyMismatchException::class);
 
         $money->mod($rightMoney);
     }
@@ -442,7 +443,7 @@ final class MoneyTest extends TestCase
     {
         $money = new Money('5', new Currency(self::CURRENCY));
 
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(CurrencyMismatchException::class);
 
         $money->compare(new Money('5', new Currency('SOME')));
     }


### PR DESCRIPTION
This PR introduces subtypes of `InvalidArgumentException`.

This improves the log analysis and allow users to rely on type instead of exception message when handling specific errors.