### PR TITLE
Ignore impure.staticPropertyAccess PHPStan errors

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "php-http/mock-client": "^1.6.0",
         "phpbench/phpbench": "^1.2.5",
         "phpstan/extension-installer": "^1.4",
-        "phpstan/phpstan": "^2.0",
+        "phpstan/phpstan": "^2.1.9",
         "phpstan/phpstan-phpunit": "^2.0",
         "phpunit/phpunit": "^10.5.9",
         "psr/cache": "^1.0.1 || ^2.0 || ^3.0",

--- a/src/Money.php
+++ b/src/Money.php
@@ -138,7 +138,7 @@ final class Money implements JsonSerializable
             throw new InvalidArgumentException('Currencies must be identical');
         }
 
-        // @phpstan-ignore possiblyImpure.methodCall
+        // @phpstan-ignore impure.staticPropertyAccess, possiblyImpure.methodCall
         return self::$calculator::compare($this->amount, $other->amount);
     }
 
@@ -212,7 +212,7 @@ final class Money implements JsonSerializable
                 throw new InvalidArgumentException('Currencies must be identical');
             }
 
-            // @phpstan-ignore possiblyImpure.methodCall
+            // @phpstan-ignore impure.staticPropertyAccess, possiblyImpure.methodCall
             $amount = self::$calculator::add($amount, $addend->amount);
         }
 
@@ -235,7 +235,7 @@ final class Money implements JsonSerializable
                 throw new InvalidArgumentException('Currencies must be identical');
             }
 
-            // @phpstan-ignore possiblyImpure.methodCall
+            // @phpstan-ignore impure.staticPropertyAccess, possiblyImpure.methodCall
             $amount = self::$calculator::subtract($amount, $subtrahend->amount);
         }
 
@@ -275,7 +275,7 @@ final class Money implements JsonSerializable
             $divisor = (string) $divisor;
         }
 
-        // @phpstan-ignore possiblyImpure.methodCall
+        // @phpstan-ignore impure.staticPropertyAccess, possiblyImpure.methodCall
         $quotient = $this->round(self::$calculator::divide($this->amount, $divisor), $roundingMode);
 
         return new self($quotient, $this->currency);
@@ -402,16 +402,16 @@ final class Money implements JsonSerializable
     private function round(string $amount, int $roundingMode): string
     {
         if ($roundingMode === self::ROUND_UP) {
-            // @phpstan-ignore possiblyImpure.methodCall
+            // @phpstan-ignore impure.staticPropertyAccess, possiblyImpure.methodCall
             return self::$calculator::ceil($amount);
         }
 
         if ($roundingMode === self::ROUND_DOWN) {
-            // @phpstan-ignore possiblyImpure.methodCall
+            // @phpstan-ignore impure.staticPropertyAccess, possiblyImpure.methodCall
             return self::$calculator::floor($amount);
         }
 
-        // @phpstan-ignore possiblyImpure.methodCall
+        // @phpstan-ignore impure.staticPropertyAccess, possiblyImpure.methodCall
         return self::$calculator::round($amount, $roundingMode);
     }
 


### PR DESCRIPTION
Since [PHPStan 2.1.9](https://github.com/phpstan/phpstan/discussions/12765), static analysis fails if it finds [impure static property access in pure method](https://github.com/phpstan/phpstan-src/commit/4111d0f5951338d3fa9735edd8ae38de90d15456).

Reasoning: Methods flagged as pure in `Money` class access the static property `self::$calculator`.

Minimal example: https://phpstan.org/r/683e4ebe-d0c0-44b5-8a2a-93684c878cd0

Note that this PR does **NOT** fix the issue. Changes are more about to push the CI to the green again.