### PR TITLE
Allow operations on Money objects with different currencies when one value is zero

### DIFF
--- a/src/Money.php
+++ b/src/Money.php
@@ -216,7 +216,6 @@ final class Money implements JsonSerializable
         $currency = $this->currency;
 
         foreach ($addends as $addend) {
-            // Note: non-strict equality is intentional here, since `Currency` is `final` and reliable.
             if (! $this->isCompatibleCurrency($addend)) {
                 throw InvalidArgumentException::currencyMismatch();
             }

--- a/src/Money.php
+++ b/src/Money.php
@@ -212,25 +212,25 @@ final class Money implements JsonSerializable
      */
     public function add(Money ...$addends): Money
     {
-        $amount   = $this->amount;
-        $currency = $this->currency;
+        $amount            = $this->amount;
+        $currencyReference = $this;
 
         foreach ($addends as $addend) {
-            if (! $this->isCompatibleCurrency($addend)) {
+            if (! $currencyReference->isCompatibleCurrency($addend)) {
                 throw InvalidArgumentException::currencyMismatch();
             }
 
             // We need to use the currency from the non-zero Money object
             if (! $addend->isZero()) {
-                // @phpstan-ignore possiblyImpure.methodCall
-                $currency = $addend->getCurrency();
+                $currencyReference = $addend;
             }
 
             // @phpstan-ignore impure.staticPropertyAccess, possiblyImpure.methodCall
             $amount = self::$calculator::add($amount, $addend->amount);
         }
 
-        return new self($amount, $currency);
+        // @phpstan-ignore possiblyImpure.methodCall
+        return new self($amount, $currencyReference->getCurrency());
     }
 
     /**
@@ -241,25 +241,25 @@ final class Money implements JsonSerializable
      */
     public function subtract(Money ...$subtrahends): Money
     {
-        $amount   = $this->amount;
-        $currency = $this->currency;
+        $amount            = $this->amount;
+        $currencyReference = $this;
 
         foreach ($subtrahends as $subtrahend) {
-            if (! $this->isCompatibleCurrency($subtrahend)) {
+            if (! $currencyReference->isCompatibleCurrency($subtrahend)) {
                 throw InvalidArgumentException::currencyMismatch();
             }
 
             // We need to use the currency from the non-zero Money object
             if (! $subtrahend->isZero()) {
-                // @phpstan-ignore possiblyImpure.methodCall
-                $currency = $subtrahend->getCurrency();
+                $currencyReference = $subtrahend;
             }
 
             // @phpstan-ignore impure.staticPropertyAccess, possiblyImpure.methodCall
             $amount = self::$calculator::subtract($amount, $subtrahend->amount);
         }
 
-        return new self($amount, $currency);
+        // @phpstan-ignore possiblyImpure.methodCall
+        return new self($amount, $currencyReference->getCurrency());
     }
 
     /**

--- a/tests/MoneyTest.php
+++ b/tests/MoneyTest.php
@@ -449,6 +449,50 @@ final class MoneyTest extends TestCase
     }
 
     /**
+     * @test
+     */
+    public function itComparesAndCalculatesZeroAmountsOfDifferentCurrencies(): void
+    {
+        $first  = new Money('0', new Currency(self::CURRENCY));
+        $second = new Money('0', new Currency(self::OTHER_CURRENCY));
+
+        $this->assertTrue($first->equals($second));
+        $this->assertTrue($first->greaterThanOrEqual($second));
+        $this->assertTrue($first->lessThanOrEqual($second));
+        $this->assertFalse($first->greaterThan($second));
+        $this->assertFalse($first->lessThan($second));
+        $this->assertEquals(0, $first->compare($second));
+        $this->assertFalse($first->isSameCurrency($second));
+        $this->assertEquals($first, $first->add($second));
+        $this->assertEquals($second, $second->add($first));
+        $this->assertEquals($first, $first->subtract($second));
+        $this->assertEquals($second, $second->subtract($first));
+    }
+
+    /**
+     * @test
+     */
+    public function itComparesAndCalculatesOneZeroAmountOfDifferentCurrency(): void
+    {
+        $first  = new Money(self::AMOUNT, new Currency(self::CURRENCY));
+        $second = new Money('0', new Currency(self::OTHER_CURRENCY));
+
+        $this->assertFalse($first->equals($second));
+        $this->assertTrue($first->greaterThanOrEqual($second));
+        $this->assertFalse($first->lessThanOrEqual($second));
+        $this->assertTrue($first->greaterThan($second));
+        $this->assertFalse($first->lessThan($second));
+        $this->assertEquals(1, $first->compare($second));
+        $this->assertFalse($first->isSameCurrency($second));
+        $this->assertEquals($first, $first->add($second));
+        $this->assertEquals($first, $second->add($first));
+        $this->assertEquals($first, $first->subtract($second));
+        $this->assertEquals($first->negative(), $second->subtract($first));
+        // Can't divide by zero, so we test "second mod first" instead of "first mod second"
+        $this->assertEquals($second, $second->mod($first));
+    }
+
+    /**
      * @phpstan-return non-empty-list<array{
      *     int|numeric-string,
      *     Currency,


### PR DESCRIPTION
This PR updates the behavior of Money to allow certain operations to proceed between objects with differing currencies **when one of the operands has a value of zero**.

### Motivation

As outlined in #807, enforcing strict currency equivalence for all comparisons and arithmetic operations—even when one operand is zero—can introduce unnecessary friction, particularly in scenarios involving default or placeholder values (e.g. initial states or empty totals). In these cases, the currency mismatch is inconsequential and may be safely ignored.

### Changes

- Introduced a new private method `isCompatibleCurrency()` which returns true if:
    - Either Money object is zero, or
    - Their currencies match
- Replaced existing strict currency checks in `equals()`, `compare()`, `add()`, `subtract()`, `mod()`, and `ratioOf()` with this new compatibility check
- Adjusted the currency used for return values in `add()` and `subtract()` to favor the non-zero operand’s currency
- Added test cases to validate behavior when one or both operands are zero but have different currencies

### Impact

This change preserves strict currency checking for non-zero values while making operations involving zeros more permissive and ergonomic. This should help avoid unnecessary exceptions in common use cases without compromising correctness.

### ⚠️ Backwards Compatibility Note

This change introduces behavior that may be considered a breaking change: previously, operations involving Money instances with an amount of zero would still enforce strict currency matching and throw an exception on mismatch. With this update, such checks are relaxed for zero values.

While it’s difficult to envision a legitimate use case where an exception should be expected when combining or comparing zero-valued money objects of differing currencies, existing code that implicitly relies on that behavior would be affected.

To support a smoother upgrade path, one potential approach considered was the introduction of an optional `$strictCurrency` argument to the constructor, indicating that the instance should enforce strict currency checks even for zero amounts. This would allow existing behavior to be preserved, however, this was not implemented in this PR to avoid complicating the constructor unless there is clear demand for it.