### PR TITLE
Introduce Currency::zero() factory for Money

### DIFF
--- a/src/Currency.php
+++ b/src/Currency.php
@@ -52,6 +52,14 @@ final class Currency implements JsonSerializable
         return $this->code === $other->code;
     }
 
+    /**
+     * Returns a new Money with zero amount in this currency.
+     */
+    public function zero(): Money
+    {
+        return new Money(0, $this);
+    }
+
     public function __toString(): string
     {
         return $this->code;

--- a/tests/CurrencyTest.php
+++ b/tests/CurrencyTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Money;
 
 use Money\Currency;
+use Money\Money;
 use PHPUnit\Framework\TestCase;
 
 use function json_encode;
@@ -43,5 +44,13 @@ final class CurrencyTest extends TestCase
     {
         $currency = new Currency('usd');
         self::assertTrue($currency->equals(new Currency('USD')));
+    }
+
+    /**
+     * @test
+     */
+    public function itCreatesZeroMoney(): void
+    {
+        self::assertTrue((new Currency('USD'))->zero()->equals(new Money(0, new Currency('USD'))));
     }
 }


### PR DESCRIPTION
This is just a nice Developer Experience improvement: 

When building up an amount through calculations, you often start from an empty Money in a known currency. The typical pattern is:

```php
$amount = new Money(0, $currency);
$amount = $amount->add(...);
```

Since the currency is usually the thing you already have in hand, reading the code flows better when the currency itself produces the zero value:

```php
$amount = $currency->zero()->add(...);
```