### PR TITLE
Fix tests in Docker for 3.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,11 @@
 FROM php:7.2-cli
 
+# Debian Buster (base of php:7.2-cli) is EOL; package indexes moved to archive.debian.org.
+RUN set -xe \
+	&& sed -i 's/deb.debian.org/archive.debian.org/g' /etc/apt/sources.list \
+	&& sed -i 's|security.debian.org/debian-security|archive.debian.org/debian-security|g' /etc/apt/sources.list \
+	&& sed -i '/buster-updates/d' /etc/apt/sources.list
+
 RUN set -xe \
 	&& apt-get update \
 	&& apt-get install -qqy libicu-dev locales libgmp-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM php:7.2-cli
+FROM php:7.4-cli-buster
 
-# Debian Buster (base of php:7.2-cli) is EOL; package indexes moved to archive.debian.org.
+# Debian Buster (base of php:7.4-cli-buster) is EOL; package indexes moved to archive.debian.org.
 RUN set -xe \
 	&& sed -i 's/deb.debian.org/archive.debian.org/g' /etc/apt/sources.list \
 	&& sed -i 's|security.debian.org/debian-security|archive.debian.org/debian-security|g' /etc/apt/sources.list \

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ $ composer test
 
 Money requires a set of dependencies, so you might want to run it in Docker.
 
+The image is based on `php:7.2-cli`, which uses Debian Buster. That release is end-of-life, so the Dockerfile points `apt` at [archive.debian.org](https://archive.debian.org/debian/) before installing extensions. Without that step, `docker build` fails during `apt-get update` with errors such as `404 Not Found` on `security.debian.org` or missing Release files for Buster.
+
 First, build the image locally:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -76,7 +76,9 @@ $ composer test
 
 Money requires a set of dependencies, so you might want to run it in Docker.
 
-The image is based on `php:7.2-cli`, which uses Debian Buster. That release is end-of-life, so the Dockerfile points `apt` at [archive.debian.org](https://archive.debian.org/debian/) before installing extensions. Without that step, `docker build` fails during `apt-get update` with errors such as `404 Not Found` on `security.debian.org` or missing Release files for Buster.
+The image is based on `php:7.4-cli-buster`, which uses Debian Buster. That release is end-of-life, so the Dockerfile points `apt` at [archive.debian.org](https://archive.debian.org/debian/) before installing extensions. Without that step, `docker build` fails during `apt-get update` with errors such as `404 Not Found` on `security.debian.org` or missing Release files for Buster.
+
+Use the same PHP major version in Docker as the one you used for `composer install` on the host. The container mounts your local `vendor/` directory; if Docker runs an older PHP (for example 7.2 while dependencies were resolved on 7.4), PHPUnit can fail with hundreds of `ParseError`s in `vendor/` (often in packages used by Prophecy, such as `phpdocumentor/reflection-docblock`).
 
 First, build the image locally:
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,21 @@ First, build the image locally:
 $ docker build -t moneyphp .
 ```
 
+Optional: run composer install fully inside Docker
+The image doesn’t include Composer. 
+One-off install, (use single quotes around the whole script — not backticks):
+
+```bash
+docker run --rm -it -v $PWD:/app -w /app moneyphp bash -c '
+  apt-get update -qq &&
+  apt-get install -y -qq git unzip &&
+  curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer &&
+  git config --global --add safe.directory /app &&
+  composer config allow-plugins.php-http/discovery true &&
+  composer install --no-interaction
+'
+```
+
 Then run the tests:
 
 ```bash


### PR DESCRIPTION
- fixes #828

- The php:7.2-cli image is based on EOL Debian Buster; apt-get update fails against the default mirrors. Point apt at archive.debian.org and document the requirement in the README.

- if Docker runs an older PHP (for example 7.2 while dependencies were resolved on 7.4), PHPUnit can fail with hundreds of `ParseError`s in `vendor/` (often in packages used by Prophecy, such as `phpdocumentor/reflection-docblock`).