### PR TITLE
`roundToUnit()` with single digit may return 100 depending on roundingMode

### DIFF
--- a/src/Money.php
+++ b/src/Money.php
@@ -17,9 +17,7 @@ use function filter_var;
 use function floor;
 use function is_int;
 use function max;
-use function str_pad;
-use function strlen;
-use function substr;
+use function pow;
 
 use const FILTER_VALIDATE_INT;
 use const PHP_ROUND_HALF_DOWN;
@@ -427,19 +425,9 @@ final class Money implements JsonSerializable
             return $this;
         }
 
-        $abs = self::$calculator::absolute($this->amount);
-        if (strlen($abs) < $unit) {
-            return new self('0', $this->currency);
-        }
+        $factor = (string) pow(10, $unit);
 
-        $toBeRounded = substr($this->amount, 0, strlen($this->amount) - $unit) . '.' . substr($this->amount, $unit * -1);
-
-        $result = $this->round($toBeRounded, $roundingMode);
-        if ($result !== '0') {
-            $result .= str_pad('', $unit, '0');
-        }
-
-        return new self($result, $this->currency);
+        return $this->divide($factor, $roundingMode)->multiply($factor);
     }
 
     public function absolute(): Money

--- a/tests/MoneyTest.php
+++ b/tests/MoneyTest.php
@@ -633,6 +633,14 @@ final class MoneyTest extends TestCase
             [1250, 2, 1300, Money::ROUND_HALF_POSITIVE_INFINITY],
             [1250, 2, 1200, Money::ROUND_HALF_NEGATIVE_INFINITY],
             [10, 2, 0, Money::ROUND_HALF_UP],
+            [-5, 2, -100, Money::ROUND_DOWN],
+            [5, 2, 100, Money::ROUND_UP],
+            [-5, 1, 0, Money::ROUND_HALF_DOWN],
+            [5, 1, 0, Money::ROUND_HALF_DOWN],
+            [-5, 1, -10, Money::ROUND_HALF_ODD],
+            [5, 1, 10, Money::ROUND_HALF_ODD],
+            [-5, 1, -10, Money::ROUND_HALF_NEGATIVE_INFINITY],
+            [5, 1, 10, Money::ROUND_HALF_POSITIVE_INFINITY],
         ];
     }
 }


### PR DESCRIPTION
```php
Money::EUR(1)->roundToUnit(2, Money::ROUND_UP);
```

incorrectly returned 0, instead of 100.

Similar mistakes might have happened with `Money::ROUND_DOWN`.

This PR makes the radical choice to recycle `$this->divide` for `roundToUnit`, instead of re-implementing manually similar calculation. It is much easier to read, and hopefully this is acceptable.